### PR TITLE
🎨 style[*]: 여러가지 레이아웃/컬러 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,9 +45,8 @@ export default function App() {
   );
 }
 
-
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/service-worker.js')
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js");
   });
 }

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -21,8 +21,8 @@ export default function Layout() {
 
   return (
     <div className="w-full min-h-[100dvh] flex justify-center bg-[black] font-pretendard">
-      <div className="w-full max-w-[414px] flex flex-col relative bg-[#FAF6F4] dark:bg-gradient-to-b dark:from-[#181718] dark:to-[#4A3551] dark:text-white min-h-[100dvh]">
-        {shouldShowTitle && <Title name={"감정 분석"} isBackActive={false} />}
+      <div className="w-full max-w-[414px] flex flex-col relative bg-[#FAF6F4] dark:bg-gradient-to-b dark:from-[#181718] dark:via-[#181718] dark:to-[#4A3551] dark:text-white min-h-[100dvh] bg-fixed">
+        {shouldShowTitle && <Title name={"감정 분석"} isBackActive={false} back={""} />}
         <main className={`flex-1 h-full ${shouldShowNav ? "pb-[84px]" : ""}`}>
           <AnimatedOutlet />
           <Toaster

--- a/src/api/queries/home/usePatchDiaryBookmark.ts
+++ b/src/api/queries/home/usePatchDiaryBookmark.ts
@@ -7,15 +7,8 @@ export const usePatchDiaryBookmark = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      token,
-      diaryId,
-      isBookmarked,
-    }: {
-      token: string;
-      diaryId: number;
-      isBookmarked: boolean;
-    }) => patchDiaryBookmark(token, diaryId, isBookmarked),
+    mutationFn: ({ diaryId, isBookmarked }: { diaryId: number; isBookmarked: boolean }) =>
+      patchDiaryBookmark(diaryId, isBookmarked),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["diaries"] });
       toast.success("북마크 상태가 변경되었습니다.", {

--- a/src/components/BottomPopup.tsx
+++ b/src/components/BottomPopup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useSpring, animated } from "@react-spring/web";
 
 type HeightOption = {
@@ -23,7 +23,7 @@ const BottomPopup = ({ isOpen, onClose, children, heightOption }: BottomPopupPro
 
   const { heightPixel: _heightPixel, wrapChildren } = heightOption || {};
   const heightPixel = wrapChildren
-    ? Math.max(contentRef.current?.offsetHeight || 0, 400) // 최소 400px 보장
+    ? Math.max(contentRef.current?.offsetHeight || 0, 200) // 최소 200px 보장
     : _heightPixel || window.innerHeight * 0.8;
 
   const [springProps, api] = useSpring(() => ({
@@ -91,16 +91,15 @@ const BottomPopup = ({ isOpen, onClose, children, heightOption }: BottomPopupPro
           onClick={handleOverlayClick}
         />
       )}
-      
+
       <animated.div
         style={{
           ...springProps,
           display: "block",
         }}
-        className="absolute bottom-0 left-0 w-full z-[100] bg-white rounded-t-2xl overflow-y-auto shadow-xl"
+        className="absolute bottom-0 left-0 w-full z-[100] bg-[#FAF6F4] dark:bg-[#1b1a1f] rounded-t-2xl overflow-y-auto shadow-xl"
         onClick={handleContentClick}
       >
-
         {/* 상단 바 */}
         <div className="w-full flex justify-center py-2">
           <div className="w-10 h-1.5 bg-gray-300 rounded-full" />

--- a/src/components/diary/MontlyCalendar.tsx
+++ b/src/components/diary/MontlyCalendar.tsx
@@ -15,7 +15,7 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
   selectedDate,
   onDateSelect,
   onClose,
-  isOpen
+  isOpen,
 }) => {
   const [currentMonth, setCurrentMonth] = useState(dayjs(selectedDate));
   const [calendarDays, setCalendarDays] = useState<(dayjs.Dayjs | null)[]>([]);
@@ -25,41 +25,41 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
   }, [currentMonth]);
 
   const generateCalendarDays = () => {
-    const startOfMonth = currentMonth.startOf('month');
-    const endOfMonth = currentMonth.endOf('month');
-    const startOfCalendar = startOfMonth.startOf('week');
-    const endOfCalendar = endOfMonth.endOf('week');
+    const startOfMonth = currentMonth.startOf("month");
+    const endOfMonth = currentMonth.endOf("month");
+    const startOfCalendar = startOfMonth.startOf("week");
+    const endOfCalendar = endOfMonth.endOf("week");
 
     const days: (dayjs.Dayjs | null)[] = [];
     let currentDay = startOfCalendar;
 
     while (currentDay.isBefore(endOfCalendar) || currentDay.isSame(endOfCalendar)) {
-      if (currentDay.isSame(startOfMonth, 'month')) {
+      if (currentDay.isSame(startOfMonth, "month")) {
         days.push(currentDay);
       } else {
         days.push(null);
       }
-      currentDay = currentDay.add(1, 'day');
+      currentDay = currentDay.add(1, "day");
     }
 
     setCalendarDays(days);
   };
 
   const handleDateClick = (date: dayjs.Dayjs) => {
-    const formattedDate = date.format('YYYY-MM-DD');
+    const formattedDate = date.format("YYYY-MM-DD");
     onDateSelect(formattedDate);
     onClose();
   };
 
   const goToPreviousMonth = () => {
-    setCurrentMonth(prev => prev.subtract(1, 'month'));
+    setCurrentMonth(prev => prev.subtract(1, "month"));
   };
 
   const goToNextMonth = () => {
-    setCurrentMonth(prev => prev.add(1, 'month'));
+    setCurrentMonth(prev => prev.add(1, "month"));
   };
 
-  const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+  const weekDays = ["일", "월", "화", "수", "목", "금", "토"];
 
   return (
     <AnimatePresence>
@@ -85,18 +85,18 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
             <div className="flex items-center justify-between mb-4">
               <button
                 onClick={goToPreviousMonth}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors text-black dark:text-white"
               >
                 <ChevronLeft className="w-5 h-5" />
               </button>
-              
-              <h2 className="text-lg font-semibold">
-                {currentMonth.format('YYYY년 M월')}
+
+              <h2 className="text-lg font-semibold text-black dark:text-white">
+                {currentMonth.format("YYYY년 M월")}
               </h2>
-              
+
               <button
                 onClick={goToNextMonth}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors text-black dark:text-white"
               >
                 <ChevronRight className="w-5 h-5" />
               </button>
@@ -108,7 +108,11 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
                 <div
                   key={day}
                   className={`text-center text-sm font-medium p-2 ${
-                    index === 0 ? 'text-red-500' : index === 6 ? 'text-blue-500' : 'text-gray-600'
+                    index === 0
+                      ? "text-red-500"
+                      : index === 6
+                        ? "text-blue-500"
+                        : "text-gray-600 dark:text-gray-300"
                   }`}
                 >
                   {day}
@@ -123,30 +127,24 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
                   return <div key={index} className="p-2" />;
                 }
 
-                const isSelected = day.format('YYYY-MM-DD') === selectedDate;
-                const isToday = day.isSame(dayjs(), 'day');
+                const isSelected = day.format("YYYY-MM-DD") === selectedDate;
+                const isToday = day.isSame(dayjs(), "day");
                 const isSunday = day.day() === 0;
                 const isSaturday = day.day() === 6;
 
                 return (
                   <button
-                    key={day.format('YYYY-MM-DD')}
+                    key={day.format("YYYY-MM-DD")}
                     onClick={() => handleDateClick(day)}
                     className={`
-                      p-2 text-sm rounded-lg transition-colors relative
-                      ${isSelected 
-                        ? 'bg-blue-500 text-white font-semibold' 
-                        : 'hover:bg-gray-100'
-                      }
-                      ${isToday && !isSelected 
-                        ? 'bg-blue-100 text-blue-600 font-semibold' 
-                        : ''
-                      }
-                      ${isSunday && !isSelected && !isToday ? 'text-red-500' : ''}
-                      ${isSaturday && !isSelected && !isToday ? 'text-blue-500' : ''}
+                      p-2 text-sm rounded-lg transition-colors relative text-black dark:text-white
+                      ${isSelected ? "bg-blue-500 text-white font-semibold" : "hover:bg-gray-100 dark:hover:bg-gray-700"}
+                      ${isToday && !isSelected ? "bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 font-semibold" : ""}
+                      ${isSunday && !isSelected && !isToday ? "text-red-500" : ""}
+                      ${isSaturday && !isSelected && !isToday ? "text-blue-500" : ""}
                     `}
                   >
-                    {day.format('D')}
+                    {day.format("D")}
                   </button>
                 );
               })}

--- a/src/components/home/ActivityAnalysisCard.tsx
+++ b/src/components/home/ActivityAnalysisCard.tsx
@@ -131,10 +131,16 @@ const ActivityAnalysisCard: React.FC<{ data?: ActivityAnalysisItem[] }> = ({ dat
               </svg>
             </div>
             <div className="text-gray-800 text-base leading-relaxed">
-              {highlightActivity(activity)}에는 <br />
+              {highlightActivity(activity)}에서 <br />
               {highlightTargets([{ name: person.name, colorKey: "blue" }])}에게{" "}
               {hasPersonEmotions ? <>{highlightEmotions(emotions)}을 느꼈고</> : <>함께했고</>}
-              {hasSelfEmotions && <> 활동에서 {highlightEmotions(selfEmotions)}을 느꼈고</>}
+              {hasSelfEmotions && (
+                <>
+                  {" "}
+                  <br />
+                  나에게는 {highlightEmotions(selfEmotions)}을 느끼고
+                </>
+              )}
               {hasStateEmotions && (
                 <>
                   {" "}

--- a/src/components/home/DiaryCards.tsx
+++ b/src/components/home/DiaryCards.tsx
@@ -71,10 +71,10 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({
             <div
               key={mappedDiary.id}
               ref={isLast && lastItemRef ? lastItemRef : undefined}
-              className="w-full bg-white rounded-2xl shadow-md p-3 flex flex-col cursor-pointer"
+              className="w-full bg-white rounded-lg shadow-md p-3 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.id)}
             >
-              <div className="flex gap-4 items-center rounded-2xl bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] mb-4 py-[14px] px-[20px]">
+              <div className="flex gap-4 items-center rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] mb-4 py-[14px] px-[20px]">
                 <div className="w-[70px] h-[70px] flex items-center justify-center rounded-full overflow-hidden">
                   <VirtualizedBlobCard
                     key={mappedDiary.id}
@@ -159,13 +159,13 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({
             <div
               key={mappedDiary.id}
               ref={isLast && lastItemRef ? lastItemRef : undefined}
-              className="w-full bg-white rounded-2xl shadow-md p-3 flex flex-col cursor-pointer"
+              className="w-full bg-white rounded-lg shadow-md p-3 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.id)}
             >
-              <div className="grid grid-cols-3 gap-2 rounded-2xl mb-2" style={{ height: "120px" }}>
+              <div className="grid grid-cols-3 gap-2 rounded-lg mb-2" style={{ height: "120px" }}>
                 {/* Blob */}
                 <div className="col-span-1 h-full">
-                  <div className="h-full w-full max-h-[120px] rounded-2xl bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
+                  <div className="h-full w-full max-h-[120px] rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
                     {/* 감정 요약 (위) */}
                     <div className="text-xs text-[#85848F] font-medium text-center ">
                       {mappedDiary.emotions && mappedDiary.emotions.length > 0
@@ -259,13 +259,13 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({
             <div
               key={mappedDiary.id}
               ref={isLast && lastItemRef ? lastItemRef : undefined}
-              className="w-full bg-white rounded-2xl shadow-md p-3 flex flex-col cursor-pointer"
+              className="w-full bg-white rounded-lg shadow-md p-3 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.id)}
             >
-              <div className="grid grid-cols-3 gap-2 rounded-2xl mb-2" style={{ height: "130px" }}>
+              <div className="grid grid-cols-3 gap-2 rounded-lg mb-2" style={{ height: "130px" }}>
                 {/* Blob */}
                 <div className="col-span-1 h-full">
-                  <div className="h-full w-full max-h-[120px] rounded-2xl bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
+                  <div className="h-full w-full max-h-[120px] rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
                     {/* 감정 요약 (위) */}
                     <div className="text-xs text-[#85848F] font-medium text-center ">
                       {mappedDiary.emotions && mappedDiary.emotions.length > 0
@@ -351,13 +351,13 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({
             <div
               key={mappedDiary.id}
               ref={isLast && lastItemRef ? lastItemRef : undefined}
-              className="w-full bg-white rounded-2xl shadow-md p-3 flex flex-col cursor-pointer"
+              className="w-full bg-white rounded-lg shadow-md p-3 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.id)}
             >
-              <div className="grid grid-cols-3 gap-2 rounded-2xl mb-2" style={{ height: "120px" }}>
+              <div className="grid grid-cols-3 gap-2 rounded-lg mb-2" style={{ height: "120px" }}>
                 {/* Blob */}
                 <div className="col-span-1 h-full">
-                  <div className="h-full w-full max-h-[120px] rounded-2xl bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
+                  <div className="h-full w-full max-h-[120px] rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
                     {/* 감정 요약 (위) */}
                     <div className="text-xs text-[#85848F] font-medium text-center ">
                       {mappedDiary.emotions && mappedDiary.emotions.length > 0
@@ -445,13 +445,13 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({
             <div
               key={mappedDiary.id}
               ref={isLast && lastItemRef ? lastItemRef : undefined}
-              className="w-full bg-white rounded-2xl shadow-md p-3 flex flex-col cursor-pointer"
+              className="w-full bg-white rounded-lg shadow-md p-3 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.id)}
             >
-              <div className="grid grid-cols-3 gap-2 rounded-2xl mb-2" style={{ height: "120px" }}>
+              <div className="grid grid-cols-3 gap-2 rounded-lg mb-2" style={{ height: "120px" }}>
                 {/* Blob */}
                 <div className="col-span-1 h-full">
-                  <div className="h-full w-full max-h-[120px] rounded-2xl bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
+                  <div className="h-full w-full max-h-[120px] rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center py-2">
                     {/* 감정 요약 (위) */}
                     <div className="text-xs text-[#85848F] font-medium text-center ">
                       {mappedDiary.emotions && mappedDiary.emotions.length > 0
@@ -533,7 +533,7 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({
             <div
               key={mappedDiary.id}
               ref={isLast && lastItemRef ? lastItemRef : undefined}
-              className="w-full bg-white rounded-2xl shadow-md p-3 flex flex-col cursor-pointer"
+              className="w-full bg-white rounded-lg shadow-md p-3 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.id)}
             >
               <div className="flex items-center justify-center h-24 text-gray-400">

--- a/src/components/home/Index.tsx
+++ b/src/components/home/Index.tsx
@@ -14,9 +14,11 @@ const Index = ({ className = "" }: { className?: string }) => {
 
       {/* 설명 텍스트 */}
       <div>
-        <h1 className="text-2xl font-bold mb-2">하루뒤 시작하기</h1>
-        <p className="text-sm text-stone-500">나만의 하루를 기록해 보세요.</p>
-        <p className="text-sm text-stone-500">시작하려면 중앙의 '+' 버튼을 탭하세요.</p>
+        <h1 className="text-2xl font-bold mb-2 text-black dark:text-white">하루뒤 시작하기</h1>
+        <p className="text-sm text-stone-500 dark:text-white">나만의 하루를 기록해 보세요.</p>
+        <p className="text-sm text-stone-500 dark:text-white">
+          시작하려면 중앙의 &apos;+&apos; 버튼을 탭하세요.
+        </p>
       </div>
     </div>
   );

--- a/src/components/result/DiaryPhotos.tsx
+++ b/src/components/result/DiaryPhotos.tsx
@@ -2,12 +2,6 @@
 
 import React from "react";
 
-const sample=[
-  "https://remotion-photo.s3.ap-northeast-2.amazonaws.com/bcdc2b34-a81e-4d51-be65-d14c4423e193.jpg",
-  "https://remotion-photo.s3.ap-northeast-2.amazonaws.com/bcdc2b34-a81e-4d51-be65-d14c4423e193.jpg",
-  "https://remotion-photo.s3.ap-northeast-2.amazonaws.com/bcdc2b34-a81e-4d51-be65-d14c4423e193.jpg",
-]
-
 interface DiaryPhotosProps {
   photos: string[]; // s3 URL 배열이라고 가정
 }
@@ -15,10 +9,10 @@ interface DiaryPhotosProps {
 const DiaryPhotos: React.FC<DiaryPhotosProps> = ({ photos }) => {
   if (!photos || photos.length === 0) return null;
 
-  const renderPhotos=()=>{
-    switch(photos.length){
+  const renderPhotos = () => {
+    switch (photos.length) {
       case 1:
-        return(
+        return (
           <div className="w-full h-[332px]">
             <img
               src={photos[0]}
@@ -26,62 +20,69 @@ const DiaryPhotos: React.FC<DiaryPhotosProps> = ({ photos }) => {
               className="object-cover w-full h-full rounded-2xl"
             />
           </div>
-        )
+        );
       case 2:
-        return(
-          <div className="h-[332px] grid grid-cols-1 gap-2">
-            {photos.map((url, idx) => (
-              <img
-                key={idx}
-                src={url}
-                alt={`Diary Photo ${idx}`}
-                className="object-cover w-full h-full rounded-lg"
-              />
-            ))}
-          </div>
-        )
-      case 3:
         return (
-          <div className="h-[332px] space-y-2">
-            {/* 상단 2개 */}
-            <div className="grid grid-cols-2 gap-2">
-              {photos.slice(1).map((url, idx) => (
+          <div className="h-[332px] space-y-3">
+            {photos.map((url, idx) => (
+              <div key={idx} className="h-[160px]">
                 <img
-                  key={idx + 1}
                   src={url}
-                  alt={`Diary Photo ${idx + 2}`}
+                  alt={`Diary Photo ${idx}`}
                   className="object-cover w-full h-full rounded-lg"
                 />
+              </div>
+            ))}
+          </div>
+        );
+      case 3:
+        return (
+          <div className="h-[332px] flex flex-col justify-between">
+            {/* 상단 2개 - 고정 높이 */}
+            <div className="grid grid-cols-2 gap-2 h-[160px]">
+              {photos.slice(1).map((url, idx) => (
+                <div key={idx + 1} className="h-[160px] w-full">
+                  <img
+                    src={url}
+                    alt={`Diary Photo ${idx + 2}`}
+                    className="object-cover w-full h-full rounded-lg"
+                  />
+                </div>
               ))}
             </div>
-            
-            {/* 하단 한개 */}
-            <img
-              src={photos[0]}
-              alt="Diary Photo 1"
-              className="object-cover w-full h-full rounded-xl"
-            />
+
+            {/* 하단 한개 - 고정 높이 */}
+            <div className="h-[160px] w-full">
+              <img
+                src={photos[0]}
+                alt="Diary Photo 1"
+                className="object-cover w-full h-full rounded-xl"
+              />
+            </div>
           </div>
         );
       case 4:
-        return(
+        return (
           <div className="h-[332px] grid grid-cols-2 gap-2">
             {photos.map((url, idx) => (
-              <img
-                key={idx}
-                src={url}
-                alt={`Diary Photo ${idx + 1}`}
-                className="object-cover w-full h-full rounded-xl"
-              />
+              <div key={idx} className="h-[160px]">
+                <img
+                  src={url}
+                  alt={`Diary Photo ${idx + 1}`}
+                  className="object-cover w-full h-full rounded-xl"
+                />
+              </div>
             ))}
           </div>
-        )
+        );
     }
-  }
+  };
 
   return (
-    <div className="rounded-2xl overflow-hidden shadow-lg">
-      {renderPhotos()}
+    <div className="w-full">
+      <div className="bg-white dark:bg-[#181718] rounded-2xl overflow-hidden shadow-lg p-[10px]">
+        {renderPhotos()}
+      </div>
     </div>
   );
 };

--- a/src/components/result/IntensityChart.tsx
+++ b/src/components/result/IntensityChart.tsx
@@ -186,8 +186,8 @@ const IntensityChart: React.FC<IntensityChartProps> = ({ scores, diaryId }) => {
   };
 
   return (
-    <div className="mb-6 overflow-visible">
-      <h2 className="text-xl font-semibold text-gray-800 mb-4 px-4">오늘까지 감정 타임라인</h2>
+    <div className="mb-6 pt-4 overflow-visible">
+      <h2 className="text-xl font-semibold text-gray-800 mb-4 px-4 ">오늘까지 감정 타임라인</h2>
       <div
         className="rounded-2xl shadow-lg p-4 overflow-visible"
         style={{ backgroundColor: "#FFFFFF" }}
@@ -216,6 +216,24 @@ const IntensityChart: React.FC<IntensityChartProps> = ({ scores, diaryId }) => {
               </filter>
             </defs>
 
+            {/* 등선들 */}
+            {[-2, -1, 0, 1, 2].map(level => {
+              const y = centerY - (level * chartHeight) / 4;
+              return (
+                <line
+                  key={level}
+                  x1={padding}
+                  y1={y}
+                  x2={chartWidth - padding}
+                  y2={y}
+                  stroke="#9CA3AF"
+                  strokeWidth="1"
+                  opacity="0.8"
+                  strokeDasharray={level === 0 ? "none" : "2,2"}
+                />
+              );
+            })}
+
             {/* 중심선 (0 기준선) */}
             <line
               x1={padding}
@@ -224,7 +242,7 @@ const IntensityChart: React.FC<IntensityChartProps> = ({ scores, diaryId }) => {
               y2={centerY}
               stroke="#9CA3AF"
               strokeWidth="2"
-              opacity="0.8"
+              opacity="1"
             />
 
             {/* 0 표시 */}
@@ -290,11 +308,21 @@ const IntensityChart: React.FC<IntensityChartProps> = ({ scores, diaryId }) => {
               </text>
             </g>
 
-            {/* 양수 영역 채우기 (연한 초록) */}
-            <path d={createSmoothAreaPath(true)} fill="url(#positiveGradient)" stroke="none" />
+            {/* 양수 영역 채우기 (연한 초록) - 투명도 증가 */}
+            <path
+              d={createSmoothAreaPath(true)}
+              fill="url(#positiveGradient)"
+              stroke="none"
+              opacity="0.3"
+            />
 
-            {/* 음수 영역 채우기 (연한 빨강) */}
-            <path d={createSmoothAreaPath(false)} fill="url(#negativeGradient)" stroke="none" />
+            {/* 음수 영역 채우기 (연한 빨강) - 투명도 증가 */}
+            <path
+              d={createSmoothAreaPath(false)}
+              fill="url(#negativeGradient)"
+              stroke="none"
+              opacity="0.3"
+            />
 
             {/* 부드러운 선 그래프 */}
             <path

--- a/src/components/result/RelationshipChangeCard.tsx
+++ b/src/components/result/RelationshipChangeCard.tsx
@@ -27,9 +27,11 @@ const RelationshipChangeCard: React.FC<RelationshipChangeCardProps> = ({ people 
                 오늘 일기로 <br />{" "}
                 {increased.map((person, index) => (
                   <span key={person.name}>
-                    <span className="text-black font-semibold">{person.name}</span>
+                    <span className="font-semibold" style={{ color: "#000" }}>
+                      {person.name}
+                    </span>
                     와의 친밀도가{" "}
-                    <span className="text-green-600 font-medium">
+                    <span className="text-green-600 dark:text-green-300 font-medium">
                       {person.changeScore.toFixed(1)}점{" "}
                     </span>
                     올랐
@@ -47,7 +49,9 @@ const RelationshipChangeCard: React.FC<RelationshipChangeCardProps> = ({ people 
                 {increased.length > 0 ? "" : "오늘 일기로 <br/> "}
                 {decreased.map((person, index) => (
                   <span key={person.name}>
-                    <span className="text-black font-semibold">{person.name}</span>
+                    <span className="font-semibold" style={{ color: "#000" }}>
+                      {person.name}
+                    </span>
                     와의 친밀도가{" "}
                     <span className="text-red-600 font-medium">
                       {Math.abs(person.changeScore).toFixed(1)}점{" "}
@@ -60,7 +64,7 @@ const RelationshipChangeCard: React.FC<RelationshipChangeCardProps> = ({ people 
               </p>
             )}
 
-            <p className="text-sm text-gray-500 mt-2 font-semibold">
+            <p style={{ color: "#000" }} className="text-sm mt-2 font-semibold">
               카드를 클릭해서 관계 변화를 확인하세요
             </p>
           </div>

--- a/src/components/result/ResultHeader.tsx
+++ b/src/components/result/ResultHeader.tsx
@@ -19,7 +19,7 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({ writtenDate }) => {
   dayjs.locale("ko");
 
   return (
-    <div className="sticky mb-8 z-10 top-0 w-full bg-[#F5F5F5]/80 backdrop-blur-md rounded-b-3xl">
+    <div className="sticky mb-8 z-10 top-0 w-full bg-[#F5F5F5]/80 dark:bg-[#181718]/80 backdrop-blur-md rounded-b-3xl">
       <div className="w-full">
         <div className="flex items-start justify-between px-4 pt-6 pb-4 w-full">
           <div className="flex flex-col">

--- a/src/components/result/ResultToggle.tsx
+++ b/src/components/result/ResultToggle.tsx
@@ -22,9 +22,7 @@ const ResultToggle: React.FC<ResultToggleProps> = ({ view }) => {
       <div className="relative grid grid-cols-2 w-fit max-w-[400px] rounded-full bg-white p-1 shadow-lg">
         <button
           className={`px-4 py-2 rounded-full font-semibold text-sm transition-all duration-300 ease-in-out ${
-            view === "record"
-              ? "bg-black text-white border-2 border-white"
-              : "bg-white text-black border-2 border-white"
+            view === "record" ? "bg-black text-white border-white" : "text-black dark:text-white"
           }`}
           onClick={() => handleTabClick("record")}
           aria-label="일기 버튼"
@@ -33,9 +31,7 @@ const ResultToggle: React.FC<ResultToggleProps> = ({ view }) => {
         </button>
         <button
           className={`px-4 py-2 rounded-full font-semibold text-sm transition-all duration-300 ease-in-out ${
-            view === "analysis"
-              ? "bg-black text-white border-2 border-white"
-              : "bg-white text-black border-2 border-white"
+            view === "analysis" ? "bg-black text-white border-white" : "text-black dark:text-white"
           }`}
           onClick={() => handleTabClick("analysis")}
           aria-label="분석 버튼"

--- a/src/components/result/RoutineRecommendCard.tsx
+++ b/src/components/result/RoutineRecommendCard.tsx
@@ -41,7 +41,7 @@ const RoutineRecommendCard: React.FC<RoutineRecommendCardProps> = ({
     const emotionInfo = getEmotionTypeDisplay(routine.routineType);
     return {
       greeting: "💌 안녕! 너에게 전하고 싶은 작은 메모야",
-      fullMessage: `요즘 ${emotionInfo.name}한 마음이 들 땐 잠깐 ${routine.content}하는 게 정말 도움이 되더라. 예전에 너도 그렇게 했을 때, 마음이 한결 가벼워졌던 거 기억나?`,
+      fullMessage: `요즘 ${emotionInfo.name}한 마음이 들 땐 잠깐 ${routine.content}하는 게 정말 도움이 되더라. <br/> 예전에 너도 그렇게 했을 때, 마음이 한결 가벼워졌던 거 기억나?`,
       suggestion: "오늘도 한 번 그렇게 해보면 어때? ",
       signature: "— 너를 늘 생각하는 마음으로",
       content: routine.content,
@@ -66,12 +66,14 @@ const RoutineRecommendCard: React.FC<RoutineRecommendCardProps> = ({
             >
               {/* 상단 인사말 */}
               <div className="text-center mb-4">
-                <p className="text-gray-700 text-base">{message.greeting}</p>
+                <p className="text-base" style={{ color: "#000" }}>
+                  {message.greeting}
+                </p>
               </div>
 
               {/* 메인 메시지 - 자연스러운 글 */}
               <div className="text-center space-y-4 mb-5">
-                <p className="text-gray-800 leading-relaxed text-base">
+                <div className="leading-relaxed text-base" style={{ color: "#000" }}>
                   {message.fullMessage.split(message.content).map((part, index) => {
                     // emotionInfo.name을 찾아서 파란색으로 강조
                     const emotionInfo = getEmotionTypeDisplay(routine.routineType);
@@ -81,16 +83,27 @@ const RoutineRecommendCard: React.FC<RoutineRecommendCardProps> = ({
                       <span key={index}>
                         {parts.map((subPart, subIndex) => (
                           <span key={subIndex}>
-                            {subPart}
+                            {subPart.split("<br/>").map((text: string, brIndex: number) => (
+                              <span key={brIndex}>
+                                {text}
+                                {brIndex < subPart.split("<br/>").length - 1 && <br />}
+                              </span>
+                            ))}
                             {subIndex < parts.length - 1 && (
-                              <span className="bg-blue-200 px-1 py-0.5 rounded-sm font-medium text-black-900">
+                              <span
+                                className="bg-blue-200 px-1 py-0.5 rounded-sm font-medium"
+                                style={{ color: "#000" }}
+                              >
                                 {emotionInfo.name}
                               </span>
                             )}
                           </span>
                         ))}
                         {index < message.fullMessage.split(message.content).length - 1 && (
-                          <span className="bg-yellow-300 px-1 py-0.5 rounded-sm font-medium relative">
+                          <span
+                            className="bg-yellow-300 px-1 py-0.5 rounded-sm font-medium relative"
+                            style={{ color: "#000" }}
+                          >
                             {message.content}
                             <span className="absolute bottom-0 left-0 w-full h-0.5 bg-yellow-400"></span>
                           </span>
@@ -98,14 +111,16 @@ const RoutineRecommendCard: React.FC<RoutineRecommendCardProps> = ({
                       </span>
                     );
                   })}
-                </p>
+                </div>
 
-                <p className="text-gray-700 font-medium">{message.suggestion}</p>
+                <p className="font-medium" style={{ color: "#000" }}>
+                  {message.suggestion}
+                </p>
               </div>
 
               {/* 서명 */}
               <div className="text-right">
-                <p className="text-gray-600 text-sm italic transform rotate-1">
+                <p className="text-sm italic transform rotate-1" style={{ color: "#000" }}>
                   {message.signature}
                 </p>
               </div>

--- a/src/pages/Diary.tsx
+++ b/src/pages/Diary.tsx
@@ -1,13 +1,9 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { Card } from "@/components/ui/card";
-import { Image as LucideImage, Mic, MicOff } from "lucide-react";
 import { usePostDiary } from "@/api/queries/diary/usePostDiary.ts";
-import Loading6 from "../components/Loading/Loading6";
 import SpeechRecognition, { useSpeechRecognition } from "react-speech-recognition";
-import { LocationPicker, LocationPreview } from "@/components/LocationPicker";
+import { LocationPicker } from "@/components/LocationPicker";
 import { useNavigate, useParams } from "react-router-dom";
 import dayjs from "dayjs";
 import FilePreview, { Attachment } from "@/components/diary/FilePreview";
@@ -69,7 +65,7 @@ const Diary = () => {
       setIsSubmitting(false);
       setAnimatedText("");
       setContentLength(0); // 글자 수 리셋
-      setSubmittedDiary(prev => prev ? { ...prev, isAnalysisDone: true } : null); // 분석 완료 신호
+      setSubmittedDiary(prev => (prev ? { ...prev, isAnalysisDone: true } : null)); // 분석 완료 신호
     },
   });
 
@@ -206,9 +202,9 @@ const Diary = () => {
       content: data.content || "",
       writtenDate: date || dayjs().format("YYYY-MM-DD"),
     };
-    
+
     setSubmittedDiary(diaryContent);
-    sessionStorage.setItem('shouldFadeFromLoading', 'true');
+    sessionStorage.setItem("shouldFadeFromLoading", "true");
 
     const formData = new FormData();
 
@@ -255,7 +251,7 @@ const Diary = () => {
   }
 
   // if (isSubmitting) return <Loading6 key={Date.now()} />;
-  if (isSubmitting)  return <Loading7 key={Date.now()}/>;
+  if (isSubmitting) return <Loading7 key={Date.now()} />;
 
   return (
     <>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -90,11 +90,10 @@ const Home = () => {
   };
 
   const handleToggleBookmark = (diaryId: number) => {
-    const token = localStorage.getItem("accessToken") || "";
     const diary = infiniteDiaries.find(d => d.id === diaryId);
     if (!diary) return;
     patchBookmark.mutate(
-      { token, diaryId, isBookmarked: !diary.bookmarked },
+      { diaryId, isBookmarked: !diary.bookmarked },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ["infiniteDiaries"] });

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -90,7 +90,7 @@ export default function Mypage() {
         </div>
 
         {/* 알림 5개 미리보기 카드*/}
-        <NotificationPreview/>
+        <NotificationPreview />
 
         {/* 계정 정보 카드 */}
         <div className="bg-card rounded-2xl shadow-lg p-6 mb-6 border">
@@ -166,7 +166,7 @@ export default function Mypage() {
           </p>
         </div>
 
-        <Webpush/>
+        <Webpush />
 
         {/* 로그아웃 버튼 */}
         <button

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -69,7 +69,6 @@
     backdrop-filter: blur(16px) saturate(180%);
     border: 1px solid rgba(255, 255, 255, 0.18);
     box-shadow: 0 4px 24px 0 rgba(0, 0, 0, 0.25);
-    z-index: 1;
     border-radius: 20px;
   }
   /* 텍스트 색상 일괄 조정 */
@@ -89,7 +88,6 @@
     background-color: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(16px) saturate(180%);
     border-radius: 20px;
-    
   }
 }
 

--- a/src/utils/highlighters.tsx
+++ b/src/utils/highlighters.tsx
@@ -23,7 +23,10 @@ export function highlightEmotions(emotions: string[]): React.ReactNode {
 // 활동 하이라이트 함수 (회색 박스)
 export function highlightActivity(activity: string): React.ReactNode {
   return (
-    <span className="inline-block px-2 py-1 rounded-md text-base font-semibold mr-1 mb-1 bg-gray-100 text-gray-800">
+    <span
+      className="inline-block px-2 py-1 rounded-md text-base font-semibold mr-1 mb-1 bg-gray-100"
+      style={{ color: "#000" }}
+    >
       {activity}
     </span>
   );


### PR DESCRIPTION
* 홈 empty 페이지 description 문구 색상 반영 (하얀색으로)
* [As-is] bg 컬러 스크롤 길이 전체에 그라데이션 적용됨 → [To-be] 뷰 사이즈만큼 그라데이션 적용되도록 변경
* 일기 결과뷰 헤더 컬러 반영
* 일기 결과뷰 > 분석 전반
* 일기 결과뷰 토글 버튼 스타일 라이트와 동일하게 변경
* 루틴 바텀시트 투명하지 않도록 변경
* Dew box radius 10으로 변경
* 사진 레이아웃변경
* 오늘에 닿은 감정의 선 부정/긍정 등선 나타내기

