### PR TITLE
feat[*] : 반응형 웹으로 리팩토링

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,206 @@
+# AGENTS.md
+
+Codebase guidelines for agentic coding operations.
+
+---
+
+## Build & Test Commands
+
+```bash
+# Development
+npm run dev           # Start Vite dev server (port 5173)
+
+# Build
+npm run build         # Production build
+
+# Linting & Formatting
+npm run lint          # Run ESLint
+npm run preview       # Preview production build
+```
+
+**Note**: No test framework is configured. Tests directory exists but contains only utility scripts.
+
+---
+
+## Project Configuration
+
+- **TypeScript**: 5.8.3, strict mode enabled
+- **React**: 19.1.0
+- **Bundler**: Vite 6.3.5
+- **State Management**: Zustand (client), TanStack Query (server)
+- **Styling**: Tailwind CSS 3.4.3 with Shadcn UI components
+- **Path Alias**: `@/*` → `src/*`
+
+---
+
+## Code Style Guidelines
+
+### Imports
+
+```tsx
+// External libraries first
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+// Type imports (use import type)
+import type { HomeResponse } from "@/types/diary";
+
+// Local imports (use @ alias for src, relative for same directory)
+import { getHomeData } from "@/api/services/home";
+import DiaryCards from "../components/home/DiaryCards";
+```
+
+### Formatting (Prettier)
+
+- **Semicolons**: Required (`semi: true`)
+- **Quotes**: Double quotes (`singleQuote: false`)
+- **Width**: 100 chars (`printWidth: 100`)
+- **Indent**: 2 spaces
+- **Trailing commas**: ES5 (`trailingComma: "es5"`)
+- **Arrow parens**: Avoid when possible (`arrowParens: "avoid"`)
+
+### Naming Conventions
+
+```tsx
+// Components: PascalCase
+const Home = () => {};
+const DiaryCards = () => {};
+
+// Hooks: camelCase with 'use' prefix
+export const useAuth = () => {};
+export const useGetHomeData = (token: string) => {};
+
+// API queries: useGet[Resource], use[Action][Resource]
+(useGetHomeData, useDeleteDiary, useCreateTodo);
+
+// Services: camelCase, descriptive verbs
+(getHomeData, createTodo, updateTodoContent);
+
+// Types/Interfaces: PascalCase
+interface HomeResponse {}
+interface ApiTodo {}
+
+// Zustand stores: use[StoreName]
+const useUserStore = create<AuthStore>(() => {});
+const useTodoStore = create<TodoStore>(() => {});
+
+// Constants: PascalCase (in constants/)
+const EMOTION_COLORS = { happy: "#FF6B6B" };
+```
+
+---
+
+## React Query Patterns
+
+```tsx
+// Query hooks: useQuery with enabled condition
+export const useGetHomeData = (token: string) => {
+  return useQuery<HomeResponse>({
+    queryKey: ["homeData", token],
+    queryFn: () => getHomeData(token),
+    enabled: !!token, // Don't fetch without token
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+  });
+};
+
+// Mutation hooks: useMutation with callbacks
+export const useDeleteDiary = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ diaryId }: { diaryId: string }) => deleteDiary(diaryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["diaries"] });
+      toast.success("Success message");
+    },
+    onError: (error: any) => {
+      console.error("Operation failed:", error);
+      toast.error("Error message");
+    },
+  });
+};
+```
+
+---
+
+## Error Handling
+
+```tsx
+// API interceptors (axios.ts) handle:
+// - 401: Automatic token refresh via refresh endpoint
+// - Failed refresh: Show logout modal, redirect to /login
+// - 500+: Log to console
+
+// Service layer: Try-catch with console.error and re-throw
+export const createTodo = async ({ content, date }) => {
+  try {
+    const response = await api.post("/todos/calendar", { content, date });
+    return response.data;
+  } catch (error) {
+    console.error("❌ createTodo error:", error);
+    throw error;
+  }
+};
+
+// Mutation layer: toast notifications for UX
+onError: (error: any) => {
+  console.error("Error:", error);
+  toast.error("Operation failed", { description: "Please try again" });
+};
+```
+
+---
+
+## Component Guidelines
+
+```tsx
+// Shadcn UI components with cn() for className merging
+import { cn } from "@/lib/utils";
+
+const Button = ({ className, variant, size, ...props }) => {
+  return <button className={cn(buttonVariants({ variant, size }), className)} {...props} />;
+};
+
+// Props interface for TypeScript
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  requireAuth?: boolean;
+}
+
+// React.forwardRef for ref forwarding
+const Component = React.forwardRef<HTMLDivElement, Props>(({ className, ...props }, ref) => {
+  return <div ref={ref} className={cn("base-styles", className)} {...props} />;
+});
+```
+
+---
+
+## ESLint Rules (Key Rules)
+
+- `unused-imports/no-unused-imports: "error"` - Auto-remove unused imports
+- `noUnusedLocals: true` - TypeScript rule
+- `noUnusedParameters: true` - TypeScript rule
+- `react-refresh/only-export-components: "warn"` - Vite HMR optimization
+
+---
+
+## Key Patterns
+
+1. **Authentication**: JWT in localStorage, refresh via HTTP-only cookie
+2. **Route Protection**: `<ProtectedRoute>` wrapper component
+3. **Toast Notifications**: Use `sonner` for success/error messages
+4. **Dark Mode**: Class-based dark mode with Tailwind
+5. **Utility Functions**: Use `cn()` from `@/lib/utils` for className merging
+6. **Query Keys**: Consistent naming like `["homeData", token]`, `["diaries"]`
+
+---
+
+## Before Committing
+
+1. Run `npm run lint` - Fix all errors
+2. Check TypeScript types - No `any` types unless absolutely necessary
+3. Remove unused imports - ESLint will auto-fix
+4. Verify error handling - Ensure try-catch and toast notifications
+5. Test authentication flows - Check 401 handling and logout behavior

--- a/CLIENT_WORK_SUMMARY.md
+++ b/CLIENT_WORK_SUMMARY.md
@@ -1,0 +1,154 @@
+# 반응형 웹 전환 작업 기록
+
+## 개요
+
+본 프로젝트를 모바일 전용 앱에서 반응형 웹(데스크탑 지원)으로 전환한 작업 기록입니다.
+
+## 작업 목록
+
+### 1. 사이드바(Sidebar) 컴포넌트 생성
+
+- **파일**: `src/components/Sidebar.tsx`
+- **내용**: 데스크탑 화면용 왼쪽 고정 사이드바 생성
+- **로고/브랜드**: "하루뒤"
+- **네비게이션 링크**: 홈, 감정 분석, 할 일, 마이페이지
+- **알림 섹션**: 알림 페이지 링크 및 알림 배지 표시
+- **일기 작성 버튼**: 오늘 날짜 기반으로 일기 작성 페이지 이동
+
+### 2. Layout.tsx 전체 구조 개편
+
+- **파일**: `src/Layout.tsx`
+- **내용**: 반응형 레이아웃 구현
+- **모바일**: 기존 `max-w-[414px]` 컨테이너 유지
+- **데스크탑**: `md:max-w-screen-xl` 적용, 사이드바 공간 확보 (`md:ml-64`)
+- **네비게이션 분기**:
+  - 모바일: `BottomNavigation` (하단 탭바)
+  - 데스크탑: `Sidebar` (왼쪽 고정 사이드바)
+- **인증 페이지**: 로그인, 회원가입에서 사이드바 숨김
+
+### 3. 홈 페이지 그리드 레이아웃
+
+- **파일**:
+  - `src/pages/Home.tsx`
+  - `src/components/home/DiaryCards.tsx`
+- **내용**: 일기 카드 리스트 반응형 그리드
+- **모바일**: 1열 (`flex-col`)
+- **태블릿**: 2열 (`md:grid-cols-2`)
+- **데스크탑**: 3열 (`lg:grid-cols-3`)
+- **간격**: 모바일 `gap-4`, 데스크탑 `md:gap-6`
+
+### 4. 감정 분석 페이지 대시보드 레이아웃
+
+- **파일**: `src/pages/Analysis.tsx`
+- **내용**: 데스크탑에서 2열 레이아웃 적용
+- **왼쪽 컬럼 (2/3)**: 감정 차트, 활동, 관계 분석
+- **오른쪽 컬럼 (1/3)**: 캐릭터(마음 속 동물)
+- **기간 선택**: 드롭다운 위치 조정 (모바일: 수직, 데스크탑: 수평)
+
+### 5. 지도(Map) 페이지 스타일링
+
+- **파일**: `src/pages/Map.tsx`
+- **내용**: 데스크탑에서 지도 컨테이너 스타일링
+- **모바일**: 전체 화면 높이
+- **데스크탑**: 고정 높이 및 둥근 효과(`md:rounded-xl md:shadow-xl`)
+
+### 6. 감정 상세 페이지 그리드 레이아웃
+
+- **파일**:
+  - `src/pages/analysis/Vitality.tsx` (활력)
+  - `src/pages/analysis/Stress.tsx` (스트레스)
+  - `src/pages/analysis/Depress.tsx` (우울)
+  - `src/pages/analysis/Anxiety.tsx` (불안)
+  - `src/pages/analysis/Stable.tsx` (안정)
+  - `src/pages/analysis/RelationBond.tsx` (유대)
+- **내용**: 각 감정별 정보 박스를 모바일 세로에서 데스크탑 그리드로 변경
+- **모바일**: 3개 박스 세로 배치
+- **태블릿**: 2열 (`md:grid-cols-2`)
+- **래지탑**: 3열 (`lg:grid-cols-3`)
+
+### 7. 할 일(Todos) 페이지 너비 최적화
+
+- **파일**: `src/components/todo/CalendarSection.tsx`
+- **내용**: 캘린더 섹션 너비 최적화
+- **데스크탑**: `md:max-w-xl md:mx-auto` 적용으로 중앙 정렬
+
+### 8. 타임라인 그래프 중앙 정렬
+
+- **파일**: `src/components/aboutMe/Mental/MentalChart.tsx`
+- **내용**: X축 텍스트 중앙 정렬
+- **변경**: `margin={{ left: 0, ... }}` → `margin={{ left: 30, ... }}`
+
+## 문제 해결 과정
+
+### 문제 1: 데스크탑에서 일기 작성 버튼 없음
+
+- **원인**: 사이드바가 없어서 일기 작성 불가
+- **해결**: 사이드바에 "일기 작성" 버튼 추가 (활성화 표시)
+
+### 문제 2: 로그인 화면에서 사이드바 보임
+
+- **원인**: `HIDE_SIDEBAR_PATHS` 배열 누락, Layout.tsx에서 조건문 오류
+- **해결**: `HIDE_SIDEBAR_PATHS` 배열 생성 및 `shouldShowSidebar` 변수로 사이드바 표시 제어
+
+### 문제 3: 로그인 화면에서 콘텐츠가 왼쪽으로 밀려있음
+
+- **원인**: 메인 콘텐츠가 항상 `flex justify-center` 적용
+- **해결**: 사이드바 존재 여부에 따라 조건부로 레이아웃 적용
+  - 사이드바 있음: `md:flex md:flex-row`
+  - 사이드바 없음: `flex justify-center`
+
+### 문제 4: 타임라인 그래프가 왼쪽으로 치우쳐짐
+
+- **원인**: XAxis `margin={{ left: 0, ... }}` 설정
+- **해결**: `margin={{ left: 30, ... }}`로 중앙 정렬
+
+## 반응형 전환 전략
+
+### Mobile First 접근법
+
+- **기본(default)**: 모바일 스타일 적용
+- **`md:` (768px+)**: 태블릿 스타일 적용
+- **`lg:` (1024px+)**: 랩지탑 스타일 적용
+
+### 주요 Breakpoint
+
+| Breakpoint | 최소 너비 | 적용 대상 |
+| ---------- | --------- | --------- |
+| (default)  | 0px       | 모바일    |
+| `md:`      | 768px     | 태블릿    |
+| `lg:`      | 1024px    | 랩지탑    |
+
+## 적용된 Tailwind 클래스 예시
+
+```tsx
+{/* 반응형 사이드바 */}
+<aside className="hidden md:flex fixed left-0 top-0 h-full w-64">
+
+{/* 반응형 그리드 */}
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+
+{/* 조건부 레이아웃 */}
+<div className={`${shouldShowSidebar ? "md:flex md:flex-row" : "flex justify-center"}`}>
+
+{/* 조건부 너비/패딩 */}
+<main className={`h-full ${
+  shouldShowSidebar ? "md:ml-64 md:max-w-screen-xl" : ""
+}`}>
+```
+
+## 기술 스택 정보
+
+- **React**: 19.1.0
+- **TypeScript**: 5.8.3 (strict mode)
+- **Bundler**: Vite 6.3.5
+- **State Management**: Zustand (클라이언트), TanStack Query (서버)
+- **Styling**: Tailwind CSS 3.4.3
+- **UI Components**: Shadcn UI
+- **Path Alias**: `@/*` → `src/*`
+- **Router**: React Router v6
+
+## 향후 개선 사항
+
+1. **ResponsiveDialog 컴포넌트**: 모바일 Drawer, 데스크탑 Dialog 래퍼 구현
+2. **테스트 코드 추가**: 다양한 화면 크기에서 레이아웃 테스트
+3. **접근성(Accessibility) 개선**: 키보드 네비게이션 지원

--- a/RESPONSIVE_PLAN.md
+++ b/RESPONSIVE_PLAN.md
@@ -1,0 +1,127 @@
+# 📱 Responsive Web Implementation Plan
+
+This document outlines the strategy for transforming the current mobile-only application into a fully responsive web application supporting Desktop views.
+
+---
+
+## 📐 Core Strategy: Mobile-First
+
+We utilize Tailwind CSS's utility-first, mobile-first approach.
+- **Default classes**: Apply to Mobile view (< 768px).
+- **`md:` prefix**: Apply to Tablet/Desktop view (>= 768px).
+- **`lg:` prefix**: Apply to Large Desktop view (>= 1024px).
+
+### 🎯 Key Breakpoints
+| Prefix | Minimum Width | Device Type | Action |
+|--------|--------------|-------------|--------|
+| (none) | 0px | Mobile | Default vertical layout |
+| `md:` | 768px | Tablet/Small Laptop | Sidebar appears, Grid 2 cols |
+| `lg:` | 1024px | Desktop | Grid 3 cols, Expanded spacing |
+
+---
+
+## 📅 Phase 1: Layout Architecture (The Shell)
+
+**Goal**: Unbind the fixed mobile width and establish desktop navigation.
+
+### 1. Global Container (`src/Layout.tsx`)
+Remove the hardcoded mobile constraints on Desktop.
+```tsx
+// Before
+<div className="max-w-[430px] mx-auto min-h-screen">
+
+// After
+<div className="w-full min-h-screen bg-background md:flex">
+  {/* Desktop Sidebar (Hidden on Mobile) */}
+  <aside className="hidden md:flex w-64 border-r fixed h-full z-50">
+     <Sidebar />
+  </aside>
+
+  {/* Main Content Area */}
+  <main className="flex-1 md:ml-64 max-w-[430px] md:max-w-screen-xl mx-auto w-full">
+     <Outlet />
+  </main>
+</div>
+```
+
+### 2. Navigation Split
+- **Mobile**: Keep `BottomNavigation.tsx`. Add `md:hidden` class.
+- **Desktop**: Create `src/components/Sidebar.tsx`.
+  - Should contain the same links as BottomNavigation.
+  - Add "Logout" button and "Profile" summary in the sidebar.
+
+---
+
+## 🧱 Phase 2: Page Layouts (The Content)
+
+**Goal**: Utilize horizontal space effectively.
+
+### 1. Home Feed (`src/pages/Home.tsx`)
+Transform the single-column list into a grid.
+```tsx
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 p-4 md:p-8">
+  {diaries.map(diary => (
+    <DiaryCard key={diary.id} {...diary} />
+  ))}
+</div>
+```
+
+### 2. Analysis & Stats (`src/pages/Analysis.tsx`)
+Move from vertical stacking to a dashboard layout.
+- **Top**: Summary cards in a row (Vitality, Stress, etc.).
+- **Body**: Charts on the Left (2/3 width), Details on the Right (1/3 width).
+```tsx
+<div className="flex flex-col md:flex-row gap-6">
+  <div className="md:w-2/3"><ChartComponent /></div>
+  <div className="md:w-1/3"><DetailPanel /></div>
+</div>
+```
+
+---
+
+## 🛠 Phase 3: Component Adaptation
+
+**Goal**: Optimize UI patterns for mouse vs. touch.
+
+### 1. Modals: Drawer vs. Dialog
+Use `useMediaQuery` to render different components based on screen size.
+- **Mobile**: `Drawer` (Slide up from bottom).
+- **Desktop**: `Dialog` (Centered modal).
+
+```tsx
+import { useMediaQuery } from "@/hooks/use-media-query"
+
+const ResponsiveDialog = ({ children }) => {
+  const isDesktop = useMediaQuery("(min-width: 768px)")
+  
+  return isDesktop ? (
+    <Dialog>{children}</Dialog>
+  ) : (
+    <Drawer>{children}</Drawer>
+  )
+}
+```
+
+### 2. Interactions
+- Add **Hover States** to all interactive elements (Cards, Buttons).
+  - `hover:bg-accent`, `hover:shadow-lg`, `hover:scale-105`.
+- **Scrollbars**: Ensure custom scrollbars are visible or styled for Desktop webkit.
+
+### 3. Maps
+- **Mobile**: Fullscreen absolute positioning.
+- **Desktop**: Container with fixed height/aspect-ratio or split-pane view.
+  - `h-[calc(100vh-bottom_nav)]` -> `md:h-[600px] md:rounded-xl`.
+
+---
+
+## ✅ Implementation Checklist
+
+- [ ] **Setup**: Update `Layout.tsx` to allow full width on `md:`.
+- [ ] **Nav**: Create `Sidebar` component and mount it conditionally.
+- [ ] **Nav**: Apply `md:hidden` to `BottomNavigation`.
+- [ ] **Home**: Apply Grid system to `DiaryCards`.
+- [ ] **UI**: Add hover effects to `Button` and `Card` components.
+- [ ] **Map**: Fix map container height for desktop view.
+- [ ] **Analysis**: Refactor stats page to use 2-column layout.
+- [ ] **Auth**: Ensure Login/Signup pages are centered nicely on large screens.
+

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,14 +1,16 @@
-import React from "react";
 import { useLocation } from "react-router-dom";
 import { useBottomPopupStore } from "./store/useBottomPopupStore";
 import BottomNavigation from "./components/BottomNavigation";
+import Sidebar from "./components/Sidebar";
 import { Toaster } from "sonner";
 import AnimatedOutlet from "./components/AnimatedOutlet";
 import Title from "./components/analysis/Title";
 
-// 하단 네비게이션을 숨길 경로 목록
+// 하단 네비게이션을 숨길 경로 목록 (인증 관련 페이지에서는 모바일 네비도 숨김)
 const HIDE_NAV_PATHS = ["/signup", "/login", "/diary", "/video", "/result", "/loading"];
 const SHOW_TITLE_PATHS = ["/analysis", "/relation"];
+// 사이드바를 숨길 경로 목록 (인증 관련 페이지에서는 데스크탑 사이드바도 숨김)
+const HIDE_SIDEBAR_PATHS = ["/signup", "/login"];
 
 export default function Layout() {
   const location = useLocation();
@@ -18,27 +20,42 @@ export default function Layout() {
   const shouldShowNav =
     !HIDE_NAV_PATHS.some(path => location.pathname.startsWith(path)) && !isPopupOpen;
 
+  // 사이드바를 보여줄지 여부 (인증 페이지는 숨김)
+  const shouldShowSidebar = !HIDE_SIDEBAR_PATHS.some(path => location.pathname.startsWith(path));
+
   const shouldShowTitle = SHOW_TITLE_PATHS.includes(location.pathname);
 
   return (
-    <div className="w-full min-h-[100dvh] flex justify-center bg-[black] font-pretendard">
+    <div className="w-full min-h-[100dvh] flex justify-center bg-black font-pretendard">
       <div
-        className="w-full max-w-[414px] flex flex-col relative bg-[#FAF6F4] dark:bg-gradient-to-b dark:from-[#181718] dark:via-[#181718] dark:to-[#4A3551] dark:text-white min-h-[100dvh] bg-fixed"
+        className={`w-full flex flex-col relative bg-[#FAF6F4] dark:bg-gradient-to-b dark:from-[#181718] dark:via-[#181718] dark:to-[#4A3551] dark:text-white min-h-[100dvh] ${
+          shouldShowSidebar ? "md:flex md:flex-row" : "flex justify-center"
+        }`}
         style={{
           backgroundAttachment: "fixed",
           backgroundSize: "100% 100%",
           backgroundRepeat: "no-repeat",
         }}
       >
-        {shouldShowTitle && (
-          <Title
-            name={location.pathname === "/relation" ? "관계 분석" : "감정 분석"}
-            isBackActive={false}
-            back={""}
-          />
-        )}
-        <main className={`flex-1 h-full ${shouldShowNav ? "pb-[84px]" : ""}`}>
-          <AnimatedOutlet />
+        {/* Desktop Sidebar - Hidden on mobile and auth pages */}
+        {shouldShowSidebar && <Sidebar />}
+
+        {/* Main Content Area - Mobile: max-w-[414px], Desktop: full width with left padding */}
+        <main
+          className={`flex-1 h-full ${
+            shouldShowSidebar ? "md:ml-64 md:max-w-screen-xl" : ""
+          } ${shouldShowNav ? "pb-[84px]" : ""}`}
+        >
+          {shouldShowTitle && (
+            <Title
+              name={location.pathname === "/relation" ? "관계 분석" : "감정 분석"}
+              isBackActive={false}
+              back=""
+            />
+          )}
+          <div className="md:px-8">
+            <AnimatedOutlet />
+          </div>
           <Toaster
             position="top-center"
             expand={true}
@@ -47,7 +64,7 @@ export default function Layout() {
             toastOptions={{
               duration: 4000,
               style: {
-                background: "#ffff",
+                background: "#ffffff",
                 color: "#EF7C80",
                 border: "1px solid #E5E5EA",
                 boxShadow: "0 4px 24px 0 rgba(80, 80, 120, 0.08)",
@@ -57,8 +74,9 @@ export default function Layout() {
           />
         </main>
 
+        {/* Mobile Bottom Navigation - Hidden on desktop */}
         {shouldShowNav && (
-          <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[414px] z-50">
+          <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[414px] z-50 md:hidden">
             <BottomNavigation />
           </div>
         )}

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 
 //import { useGetNotiCount } from "../api/queries/notifications/useGetNotiCount";
 import { Link, useLocation } from "react-router-dom";
@@ -9,7 +9,7 @@ import { useNotiStore } from "@/store/useNotiStore";
 
 export default function BottomNavigation() {
   //const { data } = useGetNotiCount();
-  
+
   const { count, fetchCount } = useNotiStore();
   // const count =data?.count ?? 0;
 
@@ -24,8 +24,7 @@ export default function BottomNavigation() {
   useEffect(() => {
     fetchCount(); // 최초 mount 시 서버에서 count 불러오기
   }, []);
-  
-  
+
   return (
     <div className="fixed bottom-0 left-0 w-full max-w-md mx-auto z-40" style={{ minWidth: 0 }}>
       <div className="relative w-full" style={{ aspectRatio: "414/84" }}>
@@ -70,7 +69,7 @@ export default function BottomNavigation() {
             d="M115.0244 40.4106C114.9778 40.7023 114.9551 40.994 114.9551 41.2856C114.9551 43.9106 117.0781 46.0327 119.6914 46.0327C119.983 46.0327 120.2631 45.9993 120.5547 45.9526V55.3657C120.5547 59.3218 118.2214 61.6674 114.2549 61.6675H105.6338C101.6662 61.6673 99.333 59.3218 99.333 55.3657V46.7339C99.333 42.7673 101.6662 40.4108 105.6338 40.4106H115.0244ZM115.2588 47.5034C114.9428 47.4686 114.6292 47.6092 114.4414 47.8657L111.6191 51.5171L108.3867 48.9741C108.1885 48.8225 107.9549 48.7632 107.7217 48.7876C107.4895 48.8226 107.2789 48.9496 107.1377 49.1362L103.6856 53.6284L103.6143 53.7339C103.4161 54.106 103.5096 54.5845 103.8594 54.8423C104.0227 54.9473 104.1982 55.0171 104.3965 55.0171C104.6659 55.0287 104.9217 54.8879 105.085 54.6675L108.0127 50.8979L111.3379 53.396L111.4434 53.4644C111.8166 53.6625 112.2835 53.5703 112.5518 53.2192L115.9229 48.8687L115.876 48.8921C116.0626 48.6354 116.0981 48.3088 115.9697 48.0171C115.8425 47.7255 115.5609 47.5267 115.2588 47.5034ZM119.8545 38.3335C121.4061 38.3335 122.6659 39.5934 122.666 41.145C122.666 42.6967 121.4062 43.9565 119.8545 43.9565C118.303 43.9564 117.043 42.6966 117.043 41.145C117.043 39.5935 118.303 38.3337 119.8545 38.3335Z"
             fill={
               isDark
-                ? path === "/analysis" || path==="/relation"
+                ? path === "/analysis" || path === "/relation"
                   ? "white"
                   : "#B6B6B6"
                 : path === "/analysis" || path === "/relation"
@@ -114,13 +113,28 @@ export default function BottomNavigation() {
 
         {/* 클릭 영역 */}
         <div className="absolute inset-0 flex justify-between items-end pb-4 px-2">
-          <Link to="/" className="flex-1 h-full" />
-          <Link to="/relation" className="flex-1 h-full" />
-          <Link to={`/diary/${today}`} className="flex-1 h-full flex justify-center items-end">
-            <div className="w-14 h-14 -mt-4 z-10 rounded-full" />
+          <Link
+            to="/"
+            className="flex-1 h-full transition-transform active:scale-95 hover:scale-105"
+          />
+          <Link
+            to="/relation"
+            className="flex-1 h-full transition-transform active:scale-95 hover:scale-105"
+          />
+          <Link
+            to={`/diary/${today}`}
+            className="flex-1 h-full flex justify-center items-end transition-transform active:scale-95 hover:scale-105"
+          >
+            <div className="w-14 h-14 -mt-4 z-10 rounded-full transition-transform hover:scale-110" />
           </Link>
-          <Link to="/todos" className="flex-1 h-full" />
-          <Link to="/mypage" className="flex-1 h-full" >
+          <Link
+            to="/todos"
+            className="flex-1 h-full transition-transform active:scale-95 hover:scale-105"
+          />
+          <Link
+            to="/mypage"
+            className="flex-1 h-full transition-transform active:scale-95 hover:scale-105"
+          >
             {/* 알림 뱃지 */}
             {count > 0 && (
               <span className="absolute top-5 right-7 bg-[#F36B6B] text-white text-[10px] font-semibold rounded-full px-1.5 py-0.5 z-50">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,103 @@
+import { Link, useLocation } from "react-router-dom";
+import { useTheme } from "@/components/theme-provider";
+import { useNotiStore } from "@/store/useNotiStore";
+import { Home, FileText, PieChart, User, Bell, Plus } from "lucide-react";
+import dayjs from "dayjs";
+
+export default function Sidebar() {
+  const location = useLocation();
+  const path = location.pathname.toLowerCase();
+  const { theme } = useTheme();
+  const { count } = useNotiStore();
+  const today = dayjs().format("YYYY-MM-DD");
+
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  const navItems = [
+    { to: "/", icon: Home, label: "홈", active: path === "/" },
+    { to: "/login", icon: User, label: "로그인", active: path === "/login" },
+    { to: "/signup", icon: User, label: "회원가입", active: path === "/signup" },
+    {
+      to: "/analysis",
+      icon: PieChart,
+      label: "감정 분석",
+      active: path === "/analysis" || path === "/relation" || path.startsWith("/analysis/"),
+    },
+    {
+      to: "/todos",
+      icon: FileText,
+      label: "할 일",
+      active: path === "/todos" || path === "/routine" || path === "/contents",
+    },
+    { to: "/mypage", icon: User, label: "마이페이지", active: path === "/mypage" },
+  ];
+
+  return (
+    <aside
+      className={`hidden md:flex flex-col fixed left-0 top-0 h-full w-64 border-r z-50 transition-colors ${
+        isDark ? "bg-[#181718] border-gray-700" : "bg-white border-gray-200"
+      }`}
+    >
+      {/* Logo/Brand */}
+      <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">하루뒤</h1>
+      </div>
+
+      {/* Navigation Links */}
+      <nav className="flex-1 p-4 space-y-2">
+        {navItems.map(item => (
+          <Link
+            key={item.label}
+            to={item.to}
+            className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-all duration-200 ${
+              item.active
+                ? "bg-[#EF7C80] text-white font-semibold"
+                : isDark
+                  ? "text-gray-300 hover:bg-gray-800 hover:text-white"
+                  : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+            }`}
+          >
+            <item.icon className="w-5 h-5" />
+            <span>{item.label}</span>
+          </Link>
+        ))}
+      </nav>
+
+      {/* Bottom Section */}
+      <div className="p-4 border-t border-gray-200 dark:border-gray-700 space-y-2">
+        {/* 일기 작성 버튼 */}
+        <Link
+          to={`/diary/${today}`}
+          className="flex items-center justify-center gap-3 px-4 py-4 rounded-lg bg-[#EF7C80] text-white font-semibold transition-all duration-200 hover:bg-[#e06b70]"
+        >
+          <Plus className="w-6 h-6" />
+          <span>일기 작성</span>
+        </Link>
+
+        {/* 알림 */}
+        <Link
+          to="/notifications"
+          className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg transition-all duration-200 ${
+            path === "/notifications"
+              ? "bg-[#EF7C80] text-white font-semibold"
+              : isDark
+                ? "text-gray-300 hover:bg-gray-800 hover:text-white"
+                : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+          }`}
+        >
+          <div className="flex items-center gap-3">
+            <Bell className="w-5 h-5" />
+            <span>알림</span>
+          </div>
+          {count > 0 && (
+            <span className="bg-[#F36B6B] text-white text-xs font-semibold rounded-full px-2 py-0.5">
+              {count}
+            </span>
+          )}
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/aboutMe/Mental/MentalChart.tsx
+++ b/src/components/aboutMe/Mental/MentalChart.tsx
@@ -237,7 +237,7 @@ const MentalChart = ({ type, data, limit }: MentalChartProps) => {
           <BarChart
             data={groupedData}
             height={100}
-            margin={{ top: 15, right: 10, left: 0, bottom: -10 }}
+            margin={{ top: 15, right: 10, left: 30, bottom: -10 }}
             barCategoryGap="20%"
             barGap={2}
           >

--- a/src/components/home/DiaryCards.tsx
+++ b/src/components/home/DiaryCards.tsx
@@ -32,12 +32,12 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
   const [openId, setOpenId] = useState<number | null>(null);
   const navigate = useNavigate();
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-  
+
   // 윈도우 크기 변화 감지
   useEffect(() => {
     const handleResize = () => setWindowWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   // 화면 크기에 따른 레이아웃 모드 결정
@@ -66,18 +66,9 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
   const MapSkeleton = ({ className }: { className?: string }) => (
     <div className={`bg-gray-200 animate-pulse rounded-lg ${className}`} />
   );
-  
 
   // LazyImage 컴포넌트 완성
-  const LazyImage = ({ 
-    src, 
-    alt, 
-    className 
-  }: { 
-    src: string; 
-    alt: string; 
-    className: string; 
-  }) => {
+  const LazyImage = ({ src, alt, className }: { src: string; alt: string; className: string }) => {
     const [isLoaded, setIsLoaded] = useState(false);
     const [hasError, setHasError] = useState(false);
 
@@ -88,7 +79,7 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
           src={src}
           alt={alt}
           className={`${className} transition-opacity duration-200 ${
-            isLoaded ? 'opacity-100' : 'opacity-0'
+            isLoaded ? "opacity-100" : "opacity-0"
           }`}
           onLoad={() => setIsLoaded(true)}
           onError={() => setHasError(true)}
@@ -121,7 +112,7 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
           src={mapUrl}
           alt="map-preview"
           className={`rounded-lg object-cover w-full h-full transition-opacity duration-200 ${
-            isLoaded ? 'opacity-100' : 'opacity-0'
+            isLoaded ? "opacity-100" : "opacity-0"
           }`}
           onLoad={() => setIsLoaded(true)}
           onError={() => setHasError(true)}
@@ -154,8 +145,12 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
 
   // 공통 컴포넌트들
   const renderBlobSection = (diary: Diary, index: number) => (
-    <div className={`h-full w-full rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center p-2 overflow-hidden ${isCompactMode ? 'min-w-0' : 'min-w-[120px] max-w-[170px]'}`}>
-      <div className={`${isCompactMode ? 'text-sm' : 'text-base'} text-[#85848F] font-medium text-center mb-2`}>
+    <div
+      className={`h-full w-full rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] flex flex-col items-center justify-center p-2 overflow-hidden ${isCompactMode ? "min-w-0" : "min-w-[120px] max-w-[170px]"}`}
+    >
+      <div
+        className={`${isCompactMode ? "text-sm" : "text-base"} text-[#85848F] font-medium text-center mb-2`}
+      >
         {diary.emotions && diary.emotions.length > 0
           ? `${diary.emotions
               .slice(0, isCompactMode ? 1 : 2)
@@ -170,7 +165,7 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
           index={index}
         />
       </div>
-      <div className={`${isCompactMode ? 'text-sm' : 'text-base'} text-[#85848F] text-center mt-2`}>
+      <div className={`${isCompactMode ? "text-sm" : "text-base"} text-[#85848F] text-center mt-2`}>
         {diary.targets && diary.targets.length > 0
           ? `${diary.targets.slice(0, isCompactMode ? 1 : 2).join(", ")}${diary.targets.length > (isCompactMode ? 1 : 2) ? " 등" : ""}`
           : "나 혼자"}
@@ -263,7 +258,10 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
   };
 
   return (
-    <div className="flex flex-col gap-2 w-full max-w-[420px] mx-auto" style={{ containerType: 'inline-size' }}>
+    <div
+      className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 w-full"
+      style={{ containerType: "inline-size" }}
+    >
       {diaries.map((mappedDiary, index) => {
         if (!mappedDiary.diaryId) {
           console.error(`❌ mappedDiary[${index}]의 diaryId가 undefined입니다!`);
@@ -312,7 +310,9 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
                       ? `${mappedDiary.emotions
                           .slice(0, 2)
                           .map(e => e.emotion)
-                          .join(", ")}${mappedDiary.emotions.length > 2 ? ` 외 ${mappedDiary.emotions.length - 2}가지 감정` : ""}`
+                          .join(
+                            ", "
+                          )}${mappedDiary.emotions.length > 2 ? ` 외 ${mappedDiary.emotions.length - 2}가지 감정` : ""}`
                       : "감정 없음"}
                   </div>
                   <div className="text-xs text-[#85848F] truncate">
@@ -341,13 +341,11 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="grid grid-cols-2 gap-2 rounded-lg mb-4" 
+              <div
+                className="grid grid-cols-2 gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
-                <div className="col-span-1 h-full">
-                  {renderBlobSection(mappedDiary, index)}
-                </div>
+                <div className="col-span-1 h-full">{renderBlobSection(mappedDiary, index)}</div>
                 <div className="col-span-1 h-full flex items-center">
                   <LazyMap diary={mappedDiary} />
                 </div>
@@ -366,8 +364,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>
@@ -393,8 +391,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>
@@ -425,8 +423,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>
@@ -463,7 +461,7 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
             >
               {isCompactMode ? (
                 // 좁은 화면에서의 레이아웃 - 스택 형태로 변경
-                <div style={{ height: 'auto' }} className="flex flex-col gap-2 rounded-lg mb-4">
+                <div style={{ height: "auto" }} className="flex flex-col gap-2 rounded-lg mb-4">
                   <div className="flex gap-2 items-center rounded-lg bg-gradient-to-b from-[#f5f6fa] to-[#e0e3ef] p-4">
                     <div className="w-[70px] h-[70px] flex-shrink-0 flex items-center justify-center rounded-full overflow-hidden">
                       <VirtualizedBlobCard
@@ -478,7 +476,9 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
                           ? `${mappedDiary.emotions
                               .slice(0, 2)
                               .map(e => e.emotion)
-                              .join(", ")}${mappedDiary.emotions.length > 2 ? ` 외 ${mappedDiary.emotions.length - 2}가지 감정` : ""}`
+                              .join(
+                                ", "
+                              )}${mappedDiary.emotions.length > 2 ? ` 외 ${mappedDiary.emotions.length - 2}가지 감정` : ""}`
                           : "감정 없음"}
                       </div>
                       <div className="text-xs text-[#85848F] truncate">
@@ -515,11 +515,13 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
                 </div>
               ) : (
                 // 일반 화면에서의 레이아웃
-                <div 
-                  className="flex gap-2 rounded-lg mb-4" 
+                <div
+                  className="flex gap-2 rounded-lg mb-4"
                   style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
                 >
-                  <div className="w-1/2 h-full flex-shrink-0">{renderBlobSection(mappedDiary, index)}</div>
+                  <div className="w-1/2 h-full flex-shrink-0">
+                    {renderBlobSection(mappedDiary, index)}
+                  </div>
                   <div className="w-1/2 grid grid-rows-2 gap-2 h-full min-w-0">
                     <div className="h-full min-h-0">
                       <LazyMap diary={mappedDiary} />
@@ -548,7 +550,6 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
           );
         }
 
-
         // 케이스 7: Blob + 사진3 (사진 3개, 지도 없음)
         if (!hasMap && imageCount === 3) {
           return (
@@ -558,8 +559,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>
@@ -599,8 +600,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>
@@ -639,8 +640,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>
@@ -686,8 +687,8 @@ const DiaryCards: React.FC<DiaryCardsProps> = ({ diaries, onDeleteDiary, lastIte
               className="w-full bg-white rounded-[20px] shadow-md p-4 flex flex-col cursor-pointer"
               onClick={() => handleCardClick(mappedDiary.diaryId)}
             >
-              <div 
-                className="flex gap-2 rounded-lg mb-4" 
+              <div
+                className="flex gap-2 rounded-lg mb-4"
                 style={{ height: `${CARD_CONTENT_HEIGHT}px` }}
               >
                 <div className="w-1/2 h-full">{renderBlobSection(mappedDiary, index)}</div>

--- a/src/components/todo/CalendarSection.tsx
+++ b/src/components/todo/CalendarSection.tsx
@@ -13,24 +13,18 @@ export default function CalendarSection() {
   const { data: monthlyStatus } = useMonthlyStatus(selectedDate);
 
   const goPrev = () => {
-    setSelectedDate(
-      view === "week" ? subWeeks(selectedDate, 1) : subMonths(selectedDate, 1)
-    );
+    setSelectedDate(view === "week" ? subWeeks(selectedDate, 1) : subMonths(selectedDate, 1));
   };
 
   const goNext = () => {
-    setSelectedDate(
-      view === "week" ? addWeeks(selectedDate, 1) : addMonths(selectedDate, 1)
-    );
+    setSelectedDate(view === "week" ? addWeeks(selectedDate, 1) : addMonths(selectedDate, 1));
   };
 
   return (
-    <div className="flex flex-col px-2 sm:px-4">
+    <div className="flex flex-col px-2 sm:px-4 md:max-w-xl md:mx-auto">
       {/* 상단 Navigation */}
       <div className="flex justify-between items-center mt-4 mb-6">
-        <div className="text-lg font-semibold">
-          {format(selectedDate, "yyyy년 M월")}
-        </div>
+        <div className="text-lg font-semibold">{format(selectedDate, "yyyy년 M월")}</div>
 
         <div className="flex items-center space-x-2 text-sm">
           <button onClick={goPrev} className="text-black dark:text-white font-black">
@@ -39,9 +33,7 @@ export default function CalendarSection() {
           <button onClick={goNext} className="text-black dark:text-white font-black">
             &gt;
           </button>
-          <span className="font-bold">
-            {view === "week" ? "주" : "월"}
-          </span>
+          <span className="font-bold">{view === "week" ? "주" : "월"}</span>
           <button
             onClick={() => setView(view === "week" ? "month" : "week")}
             className="text-gray-400 font-bold"

--- a/src/pages/Analysis.tsx
+++ b/src/pages/Analysis.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import EmotionSummaryCard from "@/components/analysis/EmotionSummaryCard";
 import EmotionSummaryCardSkeleton from "@/components/skeleton/EmotionSummaryCardSkeleton";
 import StrengthGraph from "@/components/analysis/StrengthGraph";
@@ -121,7 +121,7 @@ const Analysis = () => {
   };
 
   const data = useGetCharacter();
-  const character = data.data?.character;
+  const character = data.data?.character || "unknown";
 
   // 모든 분석 데이터가 없으면 Index 컴포넌트 표시
   if (!isDataLoading && hasNoData) {
@@ -139,8 +139,8 @@ const Analysis = () => {
     <div className="px-4 py-5 text-foreground min-h-screen space-y-6">
       {/* 기간 선택 드롭다운 - 감정 데이터가 있을 때만 표시 */}
       {(hasNegativeData || hasPositiveData) && (
-        <div className="flex justify-between gap-10">
-          <div className="w-80 bg-white rounded-xl z-40 ">
+        <div className="flex flex-col md:flex-row md:justify-between md:gap-4">
+          <div className="w-full md:w-80 bg-white rounded-xl z-40">
             <Select
               value={selectedPeriod}
               onValueChange={value => setSelectedPeriod(value as PeriodType)}
@@ -150,7 +150,7 @@ const Analysis = () => {
             />
           </div>
           {/* 도움말 버튼 */}
-          <div ref={helpRef} className="relative">
+          <div ref={helpRef} className="relative md:self-end">
             <button
               aria-label="도움말"
               className="w-9 h-9 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center shadow text-gray-600 text-xl font-bold border border-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400"
@@ -171,81 +171,87 @@ const Analysis = () => {
         </div>
       )}
 
-      {/* 부정적 감정 - 데이터가 있을 때만 표시 */}
-      {hasNegativeData && (
-        <section className="bg-white rounded-xl shadow p-5">
-          <div className="flex justify-between mb-5">
-            <h3 className="text-[21px] font-semibold mb-2 text-gray-800">부정적 감정</h3>
-            <div onClick={() => onClickHandler("부정")} className="cursor-pointer">
-              <ChevronRight className="text-gray-400" />
-            </div>
-          </div>
-          <div className="overflow-x-auto ">
-            {isLoading ? (
-              <EmotionSummaryCardSkeleton />
-            ) : (
-              <EmotionSummaryCard
-                key={"부정"}
-                type={"부정"}
-                period={getPeriodConfig(selectedPeriod).days}
-                barCount={getPeriodConfig(selectedPeriod).barCount}
-              />
-            )}
-          </div>
-        </section>
-      )}
+      {/* Desktop: 2-Column Layout for Charts */}
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Left Column: Charts */}
+        <div className="flex-1 space-y-6">
+          {/* 부정적 감정 - 데이터가 있을 때만 표시 */}
+          {hasNegativeData && (
+            <section className="bg-white rounded-xl shadow p-5">
+              <div className="flex justify-between mb-5">
+                <h3 className="text-[21px] font-semibold mb-2 text-gray-800">부정적 감정</h3>
+                <div onClick={() => onClickHandler("부정")} className="cursor-pointer">
+                  <ChevronRight className="text-gray-400" />
+                </div>
+              </div>
+              <div className="overflow-x-auto ">
+                {isLoading ? (
+                  <EmotionSummaryCardSkeleton />
+                ) : (
+                  <EmotionSummaryCard
+                    key={"부정"}
+                    type={"부정"}
+                    period={getPeriodConfig(selectedPeriod).days}
+                    barCount={getPeriodConfig(selectedPeriod).barCount}
+                  />
+                )}
+              </div>
+            </section>
+          )}
 
-      {/* 긍정적 감정 - 데이터가 있을 때만 표시 */}
-      {hasPositiveData && (
-        <section className="bg-white rounded-xl shadow p-5">
-          <div className="flex justify-between mb-5">
-            <h3 className="text-[21px] font-semibold mb-2 text-gray-800">긍정적 감정</h3>
-            <div onClick={() => onClickHandler("긍정")} className="cursor-pointer">
-              <ChevronRight className="text-gray-400" />
-            </div>
-          </div>
-          <div className="overflow-x-auto pb-2">
-            {isLoading ? (
-              <EmotionSummaryCardSkeleton />
-            ) : (
-              <EmotionSummaryCard
-                key={"긍정"}
-                type={"긍정"}
-                period={getPeriodConfig(selectedPeriod).days}
-                barCount={getPeriodConfig(selectedPeriod).barCount}
-              />
-            )}
-          </div>
-        </section>
-      )}
+          {/* 긍정적 감정 - 데이터가 있을 때만 표시 */}
+          {hasPositiveData && (
+            <section className="bg-white rounded-xl shadow p-5">
+              <div className="flex justify-between mb-5">
+                <h3 className="text-[21px] font-semibold mb-2 text-gray-800">긍정적 감정</h3>
+                <div onClick={() => onClickHandler("긍정")} className="cursor-pointer">
+                  <ChevronRight className="text-gray-400" />
+                </div>
+              </div>
+              <div className="overflow-x-auto pb-2">
+                {isLoading ? (
+                  <EmotionSummaryCardSkeleton />
+                ) : (
+                  <EmotionSummaryCard
+                    key={"긍정"}
+                    type={"긍정"}
+                    period={getPeriodConfig(selectedPeriod).days}
+                    barCount={getPeriodConfig(selectedPeriod).barCount}
+                  />
+                )}
+              </div>
+            </section>
+          )}
 
-      {/* 강점 - 데이터가 있을 때만 표시 */}
-      {hasStrengthData && (
-        <section className="bg-white rounded-xl shadow p-5">
-          <div className="flex justify-between mb-5">
-            <h3 className="text-[21px] font-semibold mb-2 text-gray-800">강점 그래프</h3>
-            <div onClick={() => onClickHandler("Strength")} className="cursor-pointer">
-              <ChevronRight className="text-gray-400" />
-            </div>
-          </div>
-          {isLoading ? <StrengthGraphSkeleton /> : <StrengthGraph />}
-        </section>
-      )}
+          {/* 강점 - 데이터가 있을 때만 표시 */}
+          {hasStrengthData && (
+            <section className="bg-white rounded-xl shadow p-5">
+              <div className="flex justify-between mb-5">
+                <h3 className="text-[21px] font-semibold mb-2 text-gray-800">강점 그래프</h3>
+                <div onClick={() => onClickHandler("Strength")} className="cursor-pointer">
+                  <ChevronRight className="text-gray-400" />
+                </div>
+              </div>
+              {isLoading ? <StrengthGraphSkeleton /> : <StrengthGraph />}
+            </section>
+          )}
+        </div>
 
-      {/* 캐릭터 - 데이터가 있을 때만 표시 */}
-      {hasCharacterData && (
-        <section className="bg-white rounded-xl shadow pt-5 pl-5 pr-5">
-          <div className="flex justify-between mb-5">
-            <h3 className="text-[21px] font-semibold mb-2 text-gray-800">
-              {nickname}님의 마음 속 동물
-            </h3>
-            <div onClick={() => onClickHandler("character")} className="cursor-pointer">
-              <ChevronRight className="text-gray-400" />
+        {/* Right Column: Character */}
+        {hasCharacterData && (
+          <section className="bg-white rounded-xl shadow pt-5 pl-5 pr-5 lg:w-1/3">
+            <div className="flex justify-between mb-5">
+              <h3 className="text-[21px] font-semibold mb-2 text-gray-800">
+                {nickname}님의 마음 속 동물
+              </h3>
+              <div onClick={() => onClickHandler("character")} className="cursor-pointer">
+                <ChevronRight className="text-gray-400" />
+              </div>
             </div>
-          </div>
-          <AnimalCard animalType={character} script="" isMain={true} />
-        </section>
-      )}
+            <AnimalCard animalType={character} script="" isMain={true} />
+          </section>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,22 +1,18 @@
 // Home.tsx
-import React, { useState, useRef, useCallback } from "react";
-import { useGetDiaryDate } from "../api/queries/home/useGetDiaryDate";
+import { useState, useRef, useCallback } from "react";
 import { useGetHomeData } from "../api/queries/home/useGetHome";
 import DiaryCards from "../components/home/DiaryCards";
 import DiaryCardsSkeleton from "../components/home/DiaryCardsSkeleton";
 import Title from "../components/home/Title";
 import Index from "../components/home/Index";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import Map from "./Map";
 import HomeBar from "@/components/home/HomeBar";
-import { useTheme } from "@/components/theme-provider";
 
 import "../styles/homeCard.css";
-import dayjs from "dayjs";
 import { useDeleteDiary } from "../api/queries/home/useDeleteDiary";
 import { useInfiniteDiaries } from "../api/queries/home/useInfiniteDiaries";
 import { useQueryClient } from "@tanstack/react-query";
-import { usePatchDiaryBookmark } from "../api/queries/home/usePatchDiaryBookmark";
 // import RecommendHome from "@/components/home/RecommendHome";
 
 // S3 → http 변환 (실제 CDN 도메인에 맞게 수정 필요)
@@ -49,15 +45,7 @@ function mapApiDiaryToDiaryCard(apiDiary: any) {
 
 const Home = () => {
   const token = localStorage.getItem("accessToken") || "";
-  const navigate = useNavigate();
   const location = useLocation();
-  const { theme } = useTheme();
-  const isDark =
-    theme === "dark" ||
-    (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-  const [selectedDate, setSelectedDate] = useState<Date>(dayjs().toDate());
-  const [errorMessage, setErrorMessage] = useState<string>("");
   const [selectedTab, setSelectedTab] = useState<"list" | "map" | "search">(
     location.state?.selectedTab || "list"
   );
@@ -66,23 +54,10 @@ const Home = () => {
 
   const queryClient = useQueryClient();
   const deleteDiaryMutation = useDeleteDiary();
-  const patchBookmark = usePatchDiaryBookmark();
 
   const handleDeleteDiary = (diaryId: number) => {
     deleteDiaryMutation.mutate(
       { diaryId: String(diaryId) },
-      {
-        onSuccess: () => {
-          // useInfiniteDiaries의 query key와 동일하게 맞춤
-          queryClient.invalidateQueries({ queryKey: ["infiniteDiaries"] });
-        },
-      }
-    );
-  };
-
-  const handleToggleBookmark = (diaryId: number) => {
-    patchBookmark.mutate(
-      { diaryId },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ["infiniteDiaries"] });
@@ -112,26 +87,13 @@ const Home = () => {
   const infiniteDiaries =
     data?.pages.flatMap(page => page.item.diaries.map(mapApiDiaryToDiaryCard)) ?? [];
 
-  // API 호출 시 string 변환
-  const { data: todayData, isLoading } = useGetDiaryDate(dayjs(selectedDate).format("YYYY-MM-DD"));
-
   // 새로운 Home API 호출
-  const { data: homeData, isLoading: homeLoading, error: homeError } = useGetHomeData(token);
+  const { data: homeData, isLoading: homeLoading } = useGetHomeData(token);
 
   // DiaryCards용 데이터 변환
   const emotionCountByMonth = homeData?.item?.emotionCountByMonth ?? 0;
   const totalDiaryCount = homeData?.item?.totalDiaryCount ?? 0;
   const continuousWritingDate = homeData?.item?.continuousWritingDate ?? 0;
-  const diaries = homeData?.item?.diaries?.map(mapApiDiaryToDiaryCard) || [];
-
-  // useEffect(() => {
-  //   if (!homeLoading && diaries.length === 0) {
-  //     setSelectedTab("map");
-  //   }
-  // }, [homeLoading, diaries]);
-
-
-  const todayDiary = todayData ? todayData : null;
 
   return (
     <div className="flex flex-col text-foreground ">
@@ -169,12 +131,14 @@ const Home = () => {
           </>
         )}
         {selectedTab === "map" && (
-          <Map
-            continuousWritingDate={continuousWritingDate}
-            emotionCountByMonth={emotionCountByMonth}
-            totalDiaryCount={totalDiaryCount}
-            initialCenter={initialCenter}
-          />
+          <div className="md:rounded-2xl md:shadow md:overflow-hidden">
+            <Map
+              continuousWritingDate={continuousWritingDate}
+              emotionCountByMonth={emotionCountByMonth}
+              totalDiaryCount={totalDiaryCount}
+              initialCenter={initialCenter}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -1,12 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Loader } from "@googlemaps/js-api-loader";
 
-interface MarkerData {
-  lat: number;
-  lng: number;
-  imageUrl?: string;
-  text?: string;
-}
 import { useGetMapData } from "../api/queries/map/useGetMapData";
 
 // API 응답 타입
@@ -22,17 +16,16 @@ interface MapProps {
   continuousWritingDate: number;
   emotionCountByMonth: number;
   totalDiaryCount: number;
-  initialCenter?: { // ✅ 초기 중심점 props 추가
+  initialCenter?: {
+    // ✅ 초기 중심점 props 추가
     lat: number;
     lng: number;
   } | null;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const Map: React.FC<MapProps> = ({ initialCenter }) => {
   const [mapInstance, setMapInstance] = useState<google.maps.Map | null>(null);
   const mapRef = useRef<HTMLDivElement | null>(null);
-  const [errorMsg, setErrorMsg] = useState("");
 
   // ✅ React Query로 지도 데이터 받아오기
   const { data: markerDataList } = useGetMapData();
@@ -58,16 +51,16 @@ const Map: React.FC<MapProps> = ({ initialCenter }) => {
 
       setMapInstance(map);
 
-        // ✅ initialCenter가 있으면 해당 위치에 마커 생성, 없으면 현재 위치 요청
-        if (initialCenter) {
-          // DiaryLocation에서 온 경우 해당 위치에 마커 표시
-          new window.google.maps.Marker({
-            position: initialCenter,
-            map,
-            icon: {
-              url:
-                "data:image/svg+xml;charset=UTF-8," +
-                encodeURIComponent(`
+      // ✅ initialCenter가 있으면 해당 위치에 마커 생성, 없으면 현재 위치 요청
+      if (initialCenter) {
+        // DiaryLocation에서 온 경우 해당 위치에 마커 표시
+        new window.google.maps.Marker({
+          position: initialCenter,
+          map,
+          icon: {
+            url:
+              "data:image/svg+xml;charset=UTF-8," +
+              encodeURIComponent(`
                   <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <!-- 막대기 (아래 부분) - 회색 -->
                     <rect x="18" y="20" width="4" height="16" fill="#666666" rx="2"/>
@@ -82,30 +75,30 @@ const Map: React.FC<MapProps> = ({ initialCenter }) => {
                     <circle cx="20" cy="16" r="2" fill="white"/>
                   </svg>
                 `),
-              scaledSize: new google.maps.Size(40, 40),
-              anchor: new google.maps.Point(20, 40),
-            },
-            title: "일기 위치",
-          });
-        } else {
-          // 일반적인 Map 접근인 경우 현재 위치 요청
-          if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(
-              position => {
-                const userLatLng = {
-                  lat: position.coords.latitude,
-                  lng: position.coords.longitude,
-                };
-  
-                map.setCenter(userLatLng);
-  
-                new window.google.maps.Marker({
-                  position: userLatLng,
-                  map,
-                  icon: {
-                    url:
-                      "data:image/svg+xml;charset=UTF-8," +
-                      encodeURIComponent(`
+            scaledSize: new google.maps.Size(40, 40),
+            anchor: new google.maps.Point(20, 40),
+          },
+          title: "일기 위치",
+        });
+      } else {
+        // 일반적인 Map 접근인 경우 현재 위치 요청
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(
+            position => {
+              const userLatLng = {
+                lat: position.coords.latitude,
+                lng: position.coords.longitude,
+              };
+
+              map.setCenter(userLatLng);
+
+              new window.google.maps.Marker({
+                position: userLatLng,
+                map,
+                icon: {
+                  url:
+                    "data:image/svg+xml;charset=UTF-8," +
+                    encodeURIComponent(`
                         <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
                           <!-- 막대기 (아래 부분) - 회색 -->
                           <rect x="18" y="20" width="4" height="16" fill="#666666" rx="2"/>
@@ -120,21 +113,20 @@ const Map: React.FC<MapProps> = ({ initialCenter }) => {
                           <circle cx="20" cy="16" r="2" fill="white"/>
                         </svg>
                       `),
-                    scaledSize: new google.maps.Size(40, 40),
-                    anchor: new google.maps.Point(20, 40),
-                  },
-                  title: "현재 위치",
-                });
-              },
-              error => {
-                setErrorMsg("현재 위치 정보를 가져올 수 없습니다.");
-                console.warn("⚠️ 위치 오류:", error.message);
-              }
-            );
-          } else {
-            setErrorMsg("이 브라우저에서는 위치 정보가 지원되지 않습니다.");
-          }
+                  scaledSize: new google.maps.Size(40, 40),
+                  anchor: new google.maps.Point(20, 40),
+                },
+                title: "현재 위치",
+              });
+            },
+            error => {
+              console.warn("⚠️ 위치 오류:", error.message);
+            }
+          );
+        } else {
+          console.warn("이 브라우저에서는 위치 정보가 지원되지 않습니다.");
         }
+      }
 
       // ✅ 마커 + 말풍선 생성 (API로 받은 markerDataList)
       (markerDataList?.result || []).forEach((markerData: ApiMarkerData) => {
@@ -291,7 +283,7 @@ const Map: React.FC<MapProps> = ({ initialCenter }) => {
           }
         }}
         className="absolute z-50 bg-[#FAF6F4] dark:bg-[#4A3551] shadow-lg rounded-lg px-3 py-2 text-sm font-medium text-black dark:text-black transition-colors"
-        style={{ left: "10px" , top: "60px"}}
+        style={{ left: "10px", top: "60px" }}
       >
         줌아웃
       </button>
@@ -299,7 +291,7 @@ const Map: React.FC<MapProps> = ({ initialCenter }) => {
       {/* 지도 컨테이너 */}
       <div
         ref={mapRef}
-        className="rounded-2xl shadow overflow-hidden"
+        className="rounded-2xl shadow overflow-hidden md:rounded-xl md:shadow-xl"
         style={{ height: "calc(100vh - 250px)", minHeight: 150 }}
       />
     </div>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useUserStore } from "@/store/userStore";
 import { useTheme } from "@/components/theme-provider";
 import NotificationPreview from "@/components/notification/NotificationPreview";
@@ -53,7 +52,7 @@ export default function Mypage() {
   const { user, logout } = useUserStore();
   const { theme, setTheme } = useTheme();
   const { data: authData, isLoading, error } = useGetAuthTest();
-  const navigate= useNavigate();
+  const navigate = useNavigate();
 
   // API 데이터에서 사용자 정보 추출
   const apiUser = authData?.user;
@@ -85,8 +84,8 @@ export default function Mypage() {
   const socialInfo = getSocialInfo(socialType);
 
   return (
-    <div className="min-h-screen overflow-auto text-foreground bg-[#fdfaf8] dark:bg-transparent px-4 pb-8">
-      <div className="max-w-md mx-auto">
+    <div className="min-h-screen overflow-auto text-foreground bg-[#fdfaf8] dark:bg-transparent md:px-8 px-4 pb-8 md:pb-12">
+      <div className="md:max-w-2xl mx-auto w-full">
         {/* 헤더 */}
         <div className="pt-8">
           <h1 className="text-3xl font-bold text-gray-900 pb-8">마이페이지</h1>
@@ -171,12 +170,14 @@ export default function Mypage() {
 
         <Webpush />
 
-        <div className="bg-card rounded-2xl shadow-lg p-6 mb-6 border cursor-pointer flex justify-between "
-          onClick={()=>navigate("/faq")}>
+        <div
+          className="bg-card rounded-2xl shadow-lg p-6 mb-6 border cursor-pointer flex justify-between "
+          onClick={() => navigate("/faq")}
+        >
           <span className="text-xl font-semibold">FAQ</span>
           <div className="text-sm text-muted-foreground flex justify-left mt-1">
-            <span className="mt-[1px] ">자주 하는 질문</span> 
-            <ChevronRight/>
+            <span className="mt-[1px] ">자주 하는 질문</span>
+            <ChevronRight />
           </div>
         </div>
 
@@ -187,7 +188,6 @@ export default function Mypage() {
         >
           로그아웃
         </button>
-
       </div>
     </div>
   );

--- a/src/pages/Todos.tsx
+++ b/src/pages/Todos.tsx
@@ -25,17 +25,17 @@ export default function TodosPage() {
   }, [urlDate]);
 
   return (
-    <div className=" overflow-auto text-foreground bg-[#fdfaf8] dark:bg-transparent px-4 pb-8">
-      <Title currentTab="todos" onTabChange={() => {}} />
+    <div className="overflow-auto text-foreground bg-[#fdfaf8] dark:bg-transparent md:px-8 px-4 pb-8 md:pb-12">
+      <Title />
 
       {/* 📅 Calendar 영역: 높이 고정 없이 자연 배치 */}
-      <div className="mt-2">
+      <div className="mt-2 md:mt-4">
         <CalendarSection />
       </div>
 
       {/* ✅ Todo 영역: Calendar 아래로 자연 흐름 */}
-      <div className="mt-6">
-        <TodoSection selectedDate={selectedDate} />
+      <div className="mt-6 md:mt-8">
+        <TodoSection />
       </div>
     </div>
   );

--- a/src/pages/analysis/Anxiety.tsx
+++ b/src/pages/analysis/Anxiety.tsx
@@ -2,50 +2,38 @@ import { useMentalData } from "@/api/queries/aboutme/useMentalData";
 import ActivitySection from "@/components/aboutMe/Mental/ActivitySection";
 import MentalChart from "@/components/aboutMe/Mental/MentalChart";
 import PeopleSection from "@/components/aboutMe/Mental/PeopleSection";
-import Stress from "@/components/analysis/Stress";
-import Depress from "@/components/analysis/Depress";
 import Title from "@/components/analysis/Title";
 import EmotionSummaryCard from "@/components/analysis/EmotionSummaryCard";
 
-const Anxiety=()=>{
-    const {data}= useMentalData("불안", 365) //최근 
-    return(
+const Anxiety = () => {
+  const period = 365; //최근
+  const barCount = 12;
+  const { data } = useMentalData("불안", period);
+  return (
+    <div className="mb-10">
+      <Title name="불안" isBackActive={true} back="/analysis" />
 
-        <div className="mb-10">
-            <Title
-                name="불안"
-                isBackActive={true}
-            />
-            <div className="pl-3 pr-3">
-
-                <div className="bg-white rounded-3xl shadow-xl mb-4">
-                    <div className="text-xl font-bold p-3"> 일자별 불안 수치</div>
-                    <MentalChart
-                        type="불안"
-                        data={data?.date??[]}
-                        limit={10}/>
-
-                </div>
-
-                <div className="bg-white rounded-3xl shadow-xl mb-4">
-                <div className="text-xl font-bold pt-5 pl-5 pb-2"> 불안을 느낀 활동</div>
-                    <ActivitySection type="불안" data={data?.activities ?? []} />
-                <div className="text-xl font-bold pt-5 pl-5 mt-10"> 불안하게 한 사람들</div>
-                    <PeopleSection type="불안" data={data?.people ?? []} />
-                </div>
-
-
-                <div className="text-2xl font-bold pt-10 mb-3">다른 심리 상태 둘러보기</div>
-                <div className="grid grid-cols-2 gap-3">
-                    <EmotionSummaryCard type={"스트레스"} color={"red"}/>
-                    <EmotionSummaryCard type={"우울"} color={"red"}/>
-                </div>
-            </div>
-
-            
+      {/* Desktop: Grid layout for multiple boxes */}
+      <div className="pl-3 pr-3 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4">
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold p-3"> 일자별 불안 수치</div>
+          <MentalChart type="불안" data={data?.date ?? []} limit={barCount} />
         </div>
-    )
 
-}
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 불안을 느낀 활동</div>
+          <ActivitySection type="불안" data={data?.activities ?? []} selectedPeriod="monthly" />
+          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 불안하게 한 사람들</div>
+          <PeopleSection type="불안" data={data?.people ?? []} selectedPeriod="monthly" />
+        </div>
+      </div>
 
+      <div className="text-2xl font-bold pt-10 pb-6 mb-3">다른 심리 상태 둘러보기</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:max-w-3xl md:mx-auto">
+        <EmotionSummaryCard type={"스트레스"} period={period} barCount={barCount} />
+        <EmotionSummaryCard type={"우울"} period={period} barCount={barCount} />
+      </div>
+    </div>
+  );
+};
 export default Anxiety;

--- a/src/pages/analysis/Depress.tsx
+++ b/src/pages/analysis/Depress.tsx
@@ -2,51 +2,38 @@ import { useMentalData } from "@/api/queries/aboutme/useMentalData";
 import ActivitySection from "@/components/aboutMe/Mental/ActivitySection";
 import MentalChart from "@/components/aboutMe/Mental/MentalChart";
 import PeopleSection from "@/components/aboutMe/Mental/PeopleSection";
-import Anxiety from "@/components/analysis/Anxiety";
 import Title from "@/components/analysis/Title";
-import Stress from "@/components/analysis/Stress";
 import EmotionSummaryCard from "@/components/analysis/EmotionSummaryCard";
 
-const Depress=()=>{
-    const {data}= useMentalData("우울", 365) //최근 
-    return(
+const Depress = () => {
+  const period = 365; //최근
+  const barCount = 12;
+  const { data } = useMentalData("우울", period);
+  return (
+    <div className="mb-10">
+      <Title name="우울" isBackActive={true} back="/analysis" />
 
-        <div className="mb-10">
-            <Title
-                name="우울"
-                isBackActive={true}
-            />
-
-            <div className="pl-3 pr-3">
-
-                <div className="bg-white rounded-3xl shadow-xl mb-4">
-                    <div className="text-xl font-bold p-3"> 일자별 우울 수치</div>
-                    <MentalChart
-                        type="우울"
-                        data={data?.date??[]}
-                        limit={10}/>
-
-                </div>
-
-                <div className="bg-white rounded-3xl shadow-xl mb-4 ">
-                    <div className="text-xl font-bold pt-5 pl-5 pb-2"> 우울감을 느낀 활동</div>
-                        <ActivitySection type="우울" data={data?.activities ?? []} />
-                    <div className="text-xl font-bold pt-5 pl-5 mt-10"> 우울에 영향을 준 사람들</div>
-                        <PeopleSection type="우울" data={data?.people ?? []}/>
-                </div>
-
-
-                <div className="text-2xl font-bold pt-10 mb-3">다른 심리 상태 둘러보기</div>
-                <div className="grid grid-cols-2 gap-3">
-                    <EmotionSummaryCard type={"스트레스"} color={"red"}/>
-                    <EmotionSummaryCard type={"불안"} color={"red"}/>
-                </div>
-            </div>
-
-            
+      {/* Desktop: Grid layout for multiple boxes */}
+      <div className="pl-3 pr-3 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4">
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold p-3"> 일자별 우울 수치</div>
+          <MentalChart type="우울" data={data?.date ?? []} limit={barCount} />
         </div>
-    )
 
-}
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 우울감을 느낀 활동</div>
+          <ActivitySection type="우울" data={data?.activities ?? []} selectedPeriod="monthly" />
+          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 우울에 영향을 주는 사람들</div>
+          <PeopleSection type="우울" data={data?.people ?? []} selectedPeriod="monthly" />
+        </div>
+      </div>
 
+      <div className="text-2xl font-bold pt-10 pb-6 mb-3">다른 심리 상태 둘러보기</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:max-w-3xl md:mx-auto">
+        <EmotionSummaryCard type={"스트레스"} period={period} barCount={barCount} />
+        <EmotionSummaryCard type={"불안"} period={period} barCount={barCount} />
+      </div>
+    </div>
+  );
+};
 export default Depress;

--- a/src/pages/analysis/RelationBond.tsx
+++ b/src/pages/analysis/RelationBond.tsx
@@ -10,24 +10,26 @@ const RelationBond = () => {
   return (
     <div className="mb-10">
       <Title name="유대" isBackActive={true} back="/analysis" />
-      <div className="pl-3 pr-3">
-        <div className="bg-white rounded-3xl shadow-xl mb-4">
+      {/* Desktop: Grid layout for multiple boxes */}
+      <div className="pl-3 pr-3 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4">
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
           <div className="text-xl font-bold p-3"> 일자별 유대 수치</div>
           <MentalChart type="유대" data={data?.date ?? []} limit={10} />
         </div>
-        <div className="bg-white rounded-3xl shadow-xl mb-4">
-          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 유대를 느낀 활동</div>
-          <ActivitySection type="유대" data={data?.activities ?? []} />
-          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 유대에 영향을 준 사람들</div>
-          <PeopleSection type="유대" data={data?.people ?? []} />
-          </div>
-          <div className="text-2xl font-bold pt-10 mb-3">다른 심리 상태 둘러보기</div>
-          <div className="grid grid-cols-2 gap-3">
-              <EmotionSummaryCard type={"활력"} color={"blue"}/>
-              <EmotionSummaryCard type={"안정"} color={"blue"}/>
-          </div>
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 유대를 늘리는 활동</div>
+          <ActivitySection type="유대" data={data?.activities ?? []} selectedPeriod="monthly" />
+          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 유대에 영향을 주는 사람들</div>
+          <PeopleSection type="유대" data={data?.people ?? []} selectedPeriod="monthly" />
+        </div>
+      </div>
+      <div className="text-2xl font-bold pt-10 pb-6 mb-3">다른 심리 상태 둘러보기</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:max-w-3xl md:mx-auto">
+            <EmotionSummaryCard type={"활력"} period={365} barCount={4}/>
+            <EmotionSummaryCard type={"안정"} period={365} barCount={4}/>
+        </div>
       </div>
     </div>
   );
 };
-export default RelationBond; 
+export default RelationBond;

--- a/src/pages/analysis/Stable.tsx
+++ b/src/pages/analysis/Stable.tsx
@@ -10,24 +10,25 @@ const Stable = () => {
   return (
     <div className="mb-10">
       <Title name="안정" isBackActive={true} back="/analysis" />
-      <div className="pl-3 pr-3">
-        <div className="bg-white rounded-3xl shadow-xl mb-4">
+      {/* Desktop: Grid layout for multiple boxes */}
+      <div className="pl-3 pr-3 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4">
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
           <div className="text-xl font-bold p-3"> 일자별 안정 수치</div>
           <MentalChart type="안정" data={data?.date ?? []} limit={10} />
         </div>
-        <div className="bg-white rounded-3xl shadow-xl mb-4">
-          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 안정을 느낀 활동</div>
-          <ActivitySection type="안정" data={data?.activities ?? []} />
-          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 안정을 준 사람들</div>
-          <PeopleSection type="안정" data={data?.people ?? []} />
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 안정을 느린 활동</div>
+          <ActivitySection type="안정" data={data?.activities ?? []} selectedPeriod="monthly" />
+          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 안정을 줄 사람들</div>
+          <PeopleSection type="안정" data={data?.people ?? []} selectedPeriod="monthly" />
         </div>
-          <div className="text-2xl font-bold pt-10 mb-3">다른 심리 상태 둘러보기</div>
-          <div className="grid grid-cols-2 gap-3">
-              <EmotionSummaryCard type={"안정"} color={"blue"}/>
-              <EmotionSummaryCard type={"유대"} color={"blue"}/>
-          </div>
+      </div>
+      <div className="text-2xl font-bold pt-10 pb-6 mb-3">다른 심리 상태 둘러보기</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:max-w-3xl md:mx-auto">
+        <EmotionSummaryCard type={"안정"} period={365} barCount={4} />
+        <EmotionSummaryCard type={"유대"} period={365} barCount={4} />
       </div>
     </div>
   );
 };
-export default Stable; 
+export default Stable;

--- a/src/pages/analysis/Stress.tsx
+++ b/src/pages/analysis/Stress.tsx
@@ -2,53 +2,37 @@ import { useMentalData } from "@/api/queries/aboutme/useMentalData";
 import ActivitySection from "@/components/aboutMe/Mental/ActivitySection";
 import MentalChart from "@/components/aboutMe/Mental/MentalChart";
 import PeopleSection from "@/components/aboutMe/Mental/PeopleSection";
-import Anxiety from "@/components/analysis/Anxiety";
-import Depress from "@/components/analysis/Depress";
 import EmotionSummaryCard from "@/components/analysis/EmotionSummaryCard";
 import Title from "@/components/analysis/Title";
 
-const Stress=()=>{
-    const period = 365; // 최근 1년
-    const barCount = 12; // 12개월 표시
-    const {data}= useMentalData("스트레스", period)
-    return(
-
-        <div className="mb-10">
-            <Title
-                name="스트레스"
-                isBackActive={true}
-                back="/analysis"
-            />
-            <div className="pl-3 pr-3">
-                <div className="bg-white rounded-3xl shadow-xl mb-4">
-                    <div className="text-xl font-bold p-3"> 일자별 스트레스 수치</div>
-                    <MentalChart
-                        type="스트레스"
-                        data={data?.date??[]}
-                        limit={barCount}/>
-
-                </div>
-
-                <div className="bg-white rounded-3xl shadow-xl mb-4">
-                    <div className="text-xl font-bold pt-5 pl-5 pb-2"> 스트레스를 유발한 활동</div>
-                        <ActivitySection type="스트레스" data={data?.activities ?? []} period={period} barCount={barCount} />
-                    <div className="text-xl font-bold pt-5 pl-5 mt-10"> 스트레스를 준 사람들</div>
-                        <PeopleSection type="스트레스" data={data?.people ?? []} period={period} barCount={barCount} />
-                </div>
-
-
-                <div className="text-2xl font-bold pt-10 mb-3">다른 심리 상태 둘러보기</div>
-                <div className="grid grid-cols-2 gap-3">
-                    <EmotionSummaryCard type={"불안"} period={period} barCount={barCount}/>
-                    <EmotionSummaryCard type={"우울"} period={period} barCount={barCount}/>
-                </div>
-
-            </div>
-
-            
+const Stress = () => {
+  const period = 365; // 최근 1년
+  const barCount = 12; // 12개월 표시
+  const { data } = useMentalData("스트레스", period);
+  return (
+    <div className="mb-10">
+      <Title name="스트레스" isBackActive={true} back="/analysis" />
+      {/* Desktop: Grid layout for multiple boxes */}
+      <div className="pl-3 pr-3 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4">
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold p-3"> 일자별 스트레스 수치</div>
+          <MentalChart type="스트레스" data={data?.date ?? []} limit={barCount} />
         </div>
-    )
 
-}
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 스트레스를 유발한 활동</div>
+          <ActivitySection type="스트레스" data={data?.activities ?? []} selectedPeriod="monthly" />
+          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 스트레스를 준 사람들</div>
+          <PeopleSection type="스트레스" data={data?.people ?? []} selectedPeriod="monthly" />
+        </div>
+      </div>
 
+      <div className="text-2xl font-bold pt-10 pb-6 mb-3">다른 심리 상태 둘러보기</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:max-w-3xl md:mx-auto">
+        <EmotionSummaryCard type={"불안"} period={period} barCount={barCount} />
+        <EmotionSummaryCard type={"우울"} period={period} barCount={barCount} />
+      </div>
+    </div>
+  );
+};
 export default Stress;

--- a/src/pages/analysis/Vitality.tsx
+++ b/src/pages/analysis/Vitality.tsx
@@ -10,24 +10,27 @@ const Vitality = () => {
   return (
     <div className="mb-10">
       <Title name="활력" isBackActive={true} back="/analysis" />
-      <div className="pl-3 pr-3">
-        <div className="bg-white rounded-3xl shadow-xl mb-4">
+      {/* Desktop: Grid layout for multiple boxes */}
+      <div className="pl-3 pr-3 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4">
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
           <div className="text-xl font-bold p-3"> 일자별 활력 수치</div>
           <MentalChart type="활력" data={data?.date ?? []} limit={10} />
         </div>
-        <div className="bg-white rounded-3xl shadow-xl mb-4">
-          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 활력을 느낀 활동</div>
-          <ActivitySection type="활력" data={data?.activities ?? []} />
-          <div className="text-xl font-bold pt-5 pl-5 mt-10"> 활력에 영향을 준 사람들</div>
-          <PeopleSection type="활력" data={data?.people ?? []} />
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 활력을 늘리는 활동</div>
+          <ActivitySection type="활력" data={data?.activities ?? []} selectedPeriod="weekly" />
         </div>
-        <div className="text-2xl font-bold pt-10 mb-3">다른 심리 상태 둘러보기</div>
-          <div className="grid grid-cols-2 gap-3">
-              <EmotionSummaryCard type={"안정"} color={"blue"}/>
-              <EmotionSummaryCard type={"유대"} color={"blue"}/>
-          </div>
+        <div className="bg-white rounded-3xl shadow-xl md:mb-0 mb-4">
+          <div className="text-xl font-bold pt-5 pl-5 pb-2"> 활력에 영향을 주는 사람들</div>
+          <PeopleSection type="활력" data={data?.people ?? []} selectedPeriod="weekly" />
+        </div>
+      </div>
+      <div className="text-2xl font-bold pt-10 pb-6 mb-3">다른 심리 상태 둘러보기</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:max-w-3xl md:mx-auto">
+        <EmotionSummaryCard type={"안정"} period={180} barCount={4} />
+        <EmotionSummaryCard type={"유대"} period={180} barCount={4} />
       </div>
     </div>
   );
 };
-export default Vitality; 
+export default Vitality;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import svgr from "vite-plugin-svgr"; // ✅ svgr import 추가
+import svgr from "vite-plugin-svgr";
 import path from "path";
 
 export default defineConfig({
   plugins: [
     react(),
-    svgr(), // ✅ svgr 플러그인 추가
+    svgr(),
   ],
   resolve: {
     alias: {
@@ -16,12 +16,5 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173,
-    // proxy: {
-    //   '/api': {
-    //     target: process.env.VITE_SOCIAL_AUTH_URL,
-    //     changeOrigin: true,
-    //     rewrite: path => path.replace(/^\/api/, '')
-    //   }
-    // }
   },
 });


### PR DESCRIPTION
# 반응형 웹 전환 작업 기록

## 개요

본 프로젝트를 모바일 전용 앱에서 반응형 웹(데스크탑 지원)으로 전환한 작업 기록입니다.

## 작업 목록

### 1. 사이드바(Sidebar) 컴포넌트 생성

- **파일**: `src/components/Sidebar.tsx`
- **내용**: 데스크탑 화면용 왼쪽 고정 사이드바 생성
- **로고/브랜드**: "하루뒤"
- **네비게이션 링크**: 홈, 감정 분석, 할 일, 마이페이지
- **알림 섹션**: 알림 페이지 링크 및 알림 배지 표시
- **일기 작성 버튼**: 오늘 날짜 기반으로 일기 작성 페이지 이동

### 2. Layout.tsx 전체 구조 개편

- **파일**: `src/Layout.tsx`
- **내용**: 반응형 레이아웃 구현
- **모바일**: 기존 `max-w-[414px]` 컨테이너 유지
- **데스크탑**: `md:max-w-screen-xl` 적용, 사이드바 공간 확보 (`md:ml-64`)
- **네비게이션 분기**:
  - 모바일: `BottomNavigation` (하단 탭바)
  - 데스크탑: `Sidebar` (왼쪽 고정 사이드바)
- **인증 페이지**: 로그인, 회원가입에서 사이드바 숨김

### 3. 홈 페이지 그리드 레이아웃

- **파일**:
  - `src/pages/Home.tsx`
  - `src/components/home/DiaryCards.tsx`
- **내용**: 일기 카드 리스트 반응형 그리드
- **모바일**: 1열 (`flex-col`)
- **태블릿**: 2열 (`md:grid-cols-2`)
- **데스크탑**: 3열 (`lg:grid-cols-3`)
- **간격**: 모바일 `gap-4`, 데스크탑 `md:gap-6`

### 4. 감정 분석 페이지 대시보드 레이아웃

- **파일**: `src/pages/Analysis.tsx`
- **내용**: 데스크탑에서 2열 레이아웃 적용
- **왼쪽 컬럼 (2/3)**: 감정 차트, 활동, 관계 분석
- **오른쪽 컬럼 (1/3)**: 캐릭터(마음 속 동물)
- **기간 선택**: 드롭다운 위치 조정 (모바일: 수직, 데스크탑: 수평)

### 5. 지도(Map) 페이지 스타일링

- **파일**: `src/pages/Map.tsx`
- **내용**: 데스크탑에서 지도 컨테이너 스타일링
- **모바일**: 전체 화면 높이
- **데스크탑**: 고정 높이 및 둥근 효과(`md:rounded-xl md:shadow-xl`)

### 6. 감정 상세 페이지 그리드 레이아웃

- **파일**:
  - `src/pages/analysis/Vitality.tsx` (활력)
  - `src/pages/analysis/Stress.tsx` (스트레스)
  - `src/pages/analysis/Depress.tsx` (우울)
  - `src/pages/analysis/Anxiety.tsx` (불안)
  - `src/pages/analysis/Stable.tsx` (안정)
  - `src/pages/analysis/RelationBond.tsx` (유대)
- **내용**: 각 감정별 정보 박스를 모바일 세로에서 데스크탑 그리드로 변경
- **모바일**: 3개 박스 세로 배치
- **태블릿**: 2열 (`md:grid-cols-2`)
- **래지탑**: 3열 (`lg:grid-cols-3`)

### 7. 할 일(Todos) 페이지 너비 최적화

- **파일**: `src/components/todo/CalendarSection.tsx`
- **내용**: 캘린더 섹션 너비 최적화
- **데스크탑**: `md:max-w-xl md:mx-auto` 적용으로 중앙 정렬

### 8. 타임라인 그래프 중앙 정렬

- **파일**: `src/components/aboutMe/Mental/MentalChart.tsx`
- **내용**: X축 텍스트 중앙 정렬
- **변경**: `margin={{ left: 0, ... }}` → `margin={{ left: 30, ... }}`

## 문제 해결 과정

### 문제 1: 데스크탑에서 일기 작성 버튼 없음

- **원인**: 사이드바가 없어서 일기 작성 불가
- **해결**: 사이드바에 "일기 작성" 버튼 추가 (활성화 표시)

### 문제 2: 로그인 화면에서 사이드바 보임

- **원인**: `HIDE_SIDEBAR_PATHS` 배열 누락, Layout.tsx에서 조건문 오류
- **해결**: `HIDE_SIDEBAR_PATHS` 배열 생성 및 `shouldShowSidebar` 변수로 사이드바 표시 제어

### 문제 3: 로그인 화면에서 콘텐츠가 왼쪽으로 밀려있음

- **원인**: 메인 콘텐츠가 항상 `flex justify-center` 적용
- **해결**: 사이드바 존재 여부에 따라 조건부로 레이아웃 적용
  - 사이드바 있음: `md:flex md:flex-row`
  - 사이드바 없음: `flex justify-center`

### 문제 4: 타임라인 그래프가 왼쪽으로 치우쳐짐

- **원인**: XAxis `margin={{ left: 0, ... }}` 설정
- **해결**: `margin={{ left: 30, ... }}`로 중앙 정렬

## 반응형 전환 전략

### Mobile First 접근법

- **기본(default)**: 모바일 스타일 적용
- **`md:` (768px+)**: 태블릿 스타일 적용
- **`lg:` (1024px+)**: 랩지탑 스타일 적용

### 주요 Breakpoint

| Breakpoint | 최소 너비 | 적용 대상 |
| ---------- | --------- | --------- |
| (default)  | 0px       | 모바일    |
| `md:`      | 768px     | 태블릿    |
| `lg:`      | 1024px    | 랩지탑    |

## 적용된 Tailwind 클래스 예시

```tsx
{/* 반응형 사이드바 */}
<aside className="hidden md:flex fixed left-0 top-0 h-full w-64">

{/* 반응형 그리드 */}
<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">

{/* 조건부 레이아웃 */}
<div className={`${shouldShowSidebar ? "md:flex md:flex-row" : "flex justify-center"}`}>

{/* 조건부 너비/패딩 */}
<main className={`h-full ${
  shouldShowSidebar ? "md:ml-64 md:max-w-screen-xl" : ""
}`}>
```

## 기술 스택 정보

- **React**: 19.1.0
- **TypeScript**: 5.8.3 (strict mode)
- **Bundler**: Vite 6.3.5
- **State Management**: Zustand (클라이언트), TanStack Query (서버)
- **Styling**: Tailwind CSS 3.4.3
- **UI Components**: Shadcn UI
- **Path Alias**: `@/*` → `src/*`
- **Router**: React Router v6

## 향후 개선 사항

1. **ResponsiveDialog 컴포넌트**: 모바일 Drawer, 데스크탑 Dialog 래퍼 구현
2. **테스트 코드 추가**: 다양한 화면 크기에서 레이아웃 테스트
3. **접근성(Accessibility) 개선**: 키보드 네비게이션 지원
